### PR TITLE
Create SNS & DynamoDB table for contracts in dev environment

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,0 +1,21 @@
+resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
+    name           = "Contracts"
+    billing_mode   = "PROVISIONED"
+    read_capacity  = 10
+    write_capacity = 10
+    hash_key       = "id"
+
+    attribute {
+        name = "id"
+        type = "S"
+    }
+
+    tags = merge(
+        local.default_tags,
+        { BackupPolicy = "Dev" }
+    )
+
+    point_in_time_recovery {
+        enabled = true
+    }
+}

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,62 +1,77 @@
-# INSTRUCTIONS: 
-# 1) ENSURE YOU POPULATE THE LOCALS 
-# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# INSTRUCTIONS:
+# 1) ENSURE YOU POPULATE THE LOCALS
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
 # 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
 # 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
 # 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
 # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
 # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
+terraform {
+    required_providers {
+        aws = {
+            source  = "hashicorp/aws"
+            version = "~> 3.0"
+        }
+    }
+}
+
 provider "aws" {
   region  = "eu-west-2"
-  version = "~> 2.0"
 }
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+
 locals {
-  application_name = your application name # The name to use for your application
    parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
-
-data "aws_iam_role" "ec2_container_service_role" {
-  name = "ecsServiceRole"
-}
-
-data "aws_iam_role" "ecs_task_execution_role" {
-  name = "ecsTaskExecutionRole"
+    default_tags = {
+        Name              = "contracts-api-${var.environment_name}"
+        Environment       = var.environment_name
+        terraform-managed = true
+        project_name      = var.project_name
+    }
 }
 
 terraform {
   backend "s3" {
-    bucket  = "terraform-state-development-apis"
+    bucket  = "terraform-state-housing-development"
     encrypt = true
     region  = "eu-west-2"
-    key     = services/YOUR API NAME/state #e.g. "services/transactions-api/state"
+    key     = "services/contracts-api/state"
   }
 }
 
-module "development" {
-  # Delete as appropriate:
-  source                      = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/fargate"
-  # source = "github.com/LBHackney-IT/aws-hackney-components-per-service-terraform.git//modules/environment/backend/ec2"
-  cluster_name                = "development-apis"
-  ecr_name                    = ecr repository name # Replace with your repository name - pattern: "hackney/YOUR APP NAME"
-  environment_name            = "development"
-  application_name            = local.application_name 
-  security_group_name         = back end security group name # Replace with your security group name, WITHOUT SPECIFYING environment. Usually the SG has the name of your API
-  vpc_name                    = "vpc-development-apis"
-  host_port                   = port # Replace with the port to use for your api / app
-  port                        = port # Replace with the port to use for your api / app
-  desired_number_of_ec2_nodes = number of nodes # Variable will only be used if EC2 is required. Do not remove it. 
-  lb_prefix                   = "nlb-development-apis"
-  ecs_execution_role          = data.aws_iam_role.ecs_task_execution_role.arn
-  lb_iam_role_arn             = data.aws_iam_role.ec2_container_service_role.arn
-  task_definition_environment_variables = {
-    ASPNETCORE_ENVIRONMENT = "development"
-  }
-  task_definition_environment_variable_count = number # This number needs to reflect the number of environment variables provided
-  cost_code = your project's cost code
-  task_definition_secrets      = {}
-  task_definition_secret_count = number # This number needs to reflect the number of environment variables provided
+resource "aws_sns_topic" "contracts" {
+    name                        = "contracts.fifo"
+    fifo_topic                  = true
+    content_based_deduplication = true
+    kms_master_key_id           = "alias/aws/sns"
+}
+
+resource "aws_ssm_parameter" "contract_sns_arn" {
+    name  = "/sns-topic/development/tenure/arn"
+    type  = "String"
+    value = aws_sns_topic.contracts.arn
+}
+
+module "contracts_api_cloudwatch_dashboard" {
+    source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
+    environment_name    = var.environment_name
+    api_name            = "contracts-api"
+    sns_topic_name      = aws_sns_topic.contracts.name
+    dynamodb_table_name = aws_dynamodb_table.contractsapi_dynamodb_table.name
+    include_sns_widget  = false
+}
+
+data "aws_ssm_parameter" "cloudwatch_topic_arn" {
+    name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"
+}
+
+module "api-alarm" {
+    source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
+    environment_name = var.environment_name
+    api_name         = "contracts-api"
+    alarm_period     = "300"
+    error_threshold  = "1"
+    sns_topic_arn    = data.aws_ssm_parameter.cloudwatch_topic_arn.value
 }

--- a/terraform/development/terraform-compliance/dynamodb.feature
+++ b/terraform/development/terraform-compliance/dynamodb.feature
@@ -1,0 +1,14 @@
+Feature: DynamoDB is used as our NoSQL database service
+  In order to improve security
+  As engineers
+  We'll ensure our DynamoDB tables are configured correctly
+
+  Scenario: Ensure BackupPolicy tag is present
+    Given I have aws_dynamodb_table defined
+    Then it must contain tags
+    And it must contain BackupPolicy
+
+  Scenario: Ensure point in time recovery enabled
+    Given I have aws_dynamodb_table defined
+    Then it must contain point_in_time_recovery
+    And its enabled property must be true

--- a/terraform/development/terraform-compliance/sns.feature
+++ b/terraform/development/terraform-compliance/sns.feature
@@ -1,0 +1,8 @@
+Feature: SNS is used as our notification service
+    In order to improve security
+    As engineers
+    We'll use ensure our SNS topics are configured correctly
+
+    Scenario: Ensure encryption is enabled
+        Given I have aws_sns_topic defined
+        Then it must contain kms_master_key_id

--- a/terraform/development/variables.tf
+++ b/terraform/development/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+    type    = string
+    default = "development"
+}
+
+variable "project_name" {
+    type    = string
+    default = "Housing-Development"
+}


### PR DESCRIPTION
### What
This PR adds the terraform configuration to create a number of AWS services for contracts in the development environment:

- A SNS queue
- A DynamoDB table
- Cloudwatch dashboard
- API alarm

### Why
The main purpose is to allow terraform to create the required infrastructure needed to store and monitor contracts data in the dev environment.
### Anything else?
This PR is to just get the terraform ready and won't be deployed just yet once merged in. A future PR will be created once the pipeline is updated to create these resources