### PR TITLE
API lambda can now communicate with DynamoDB & SNS

### DIFF
--- a/ContractsApi/policies/require-authorizer.js
+++ b/ContractsApi/policies/require-authorizer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = function authorizerPolicy(policy, service) {
+    let failed = false;
+    const functions = service.compiled['serverless-state.json'].service.functions;
+
+    if (!functions) {
+        policy.approve();
+        return;
+    }
+
+    Object.entries(functions).forEach(([functionName, functionConfig]) => {
+        if (!functionConfig.events) return;
+
+        functionConfig.events.forEach((eventConfig) => {
+            if (!eventConfig.http) return;
+            if (!eventConfig.http.authorizer & !eventConfig.http.path=="/swagger/{proxy+}") {
+                failed = true;
+                policy.fail(
+                    `Function "${functionName}" does not have an authorizer attached to it. `
+                );
+            }
+        });
+    });
+    if (!failed) {
+        policy.approve();
+    }
+};

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -8,20 +8,13 @@ provider:
     apiGateway: true
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
-  # TODO: Enable this line if DynamoDb is in use
-  #account: ${opt:account}
   region: eu-west-2
-  apiKeys:
-    - secureAccess:
-      - api-key-${self:service}-${self:provider.stage}
-  usagePlan:
-    - secureAccess:
-        throttle:
-          burstLimit: 200
-          rateLimit: 100
+
+plugins:
+  - serverless-associate-waf
+  - '@serverless/safeguards-plugin'
 
 package:
-# TODO: Rename zipfile in build.sh and build.cmd to match this
   artifact: ./bin/release/netcoreapp3.1/contracts-api.zip
 
 functions:
@@ -30,9 +23,7 @@ functions:
     handler: ContractsApi::ContractsApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-# TODO: Create ssm variables for this API's postgres mirror then rename contracts-api below to match api name
-# TODO: Remove this line if DynamoDb is being used
-      CONNECTION_STRING: Host=${ssm:/contracts-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/contracts-api/${self:provider.stage}/postgres-port};Database=contracts-api-mirror;Username=${ssm:/contracts-api/${self:provider.stage}/postgres-username};Password=${ssm:/contracts-api/${self:provider.stage}/postgres-password}
+      CONTRACTS_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
     events:
       - http:
           path: /{proxy+}
@@ -72,6 +63,15 @@ resources:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
         Policies:
+          - PolicyName: postToSns
+            PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "sns:Publish"
+                    Resource:
+                      - ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
           - PolicyName: manageLogs
             PolicyDocument:
               Version: '2012-10-17'
@@ -105,7 +105,37 @@ resources:
                   Action:
                     - "lambda:InvokeFunction"
                   Resource: "*"
+          - PolicyName: dynamoDBAccess
+            PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "dynamodb:BatchGet*"
+                      - "dynamodb:BatchWrite"
+                      - "dynamodb:DeleteItem"
+                      - "dynamodb:DescribeStream"
+                      - "dynamodb:DescribeTable"
+                      - "dynamodb:Get*"
+                      - "dynamodb:PutItem"
+                      - "dynamodb:Query"
+                      - "dynamodb:Scan"
+                      - "dynamodb:UpdateItem"
+                    Resource:
+                      - 'Fn::Join':
+                          - ':'
+                          - - 'arn:aws:dynamodb'
+                            - Ref: 'AWS::Region'
+                            - Ref: 'AWS::AccountId'
+                            - 'table/Contracts'
 custom:
+  safeguards:
+    - title: Require authorizer
+      safeguard: require-authorizer
+      path: ./policies
+  associateWaf:
+    name: Platform_APIs_Web_ACL
+    version: V2
   vpc:
     development:
       subnetIds:


### PR DESCRIPTION
### What
This PR updates the serverless config to allow the lambda to communicate with DynamoDB and SNS. The lambda authorizer has also been added to control access.
### Why
To allow the API lambda to access Dynamo DB for contract data and for the lambda authorizer to secure access to the lambda.
### Anything else?
Similar to the dev terraform PR this will be deployed once the pipeline has been updated.