### PR TITLE
Pipeline deploys lambda to AWS dev environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: circleci/python:3.7
   docker-terraform:
     docker:
-      - image: "hashicorp/terraform:light"
+      - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:3.1
@@ -38,8 +38,8 @@ commands:
           root: *workspace_root
           paths:
             - .aws
-  terraform-init-then-apply:
-    description: "Initializes and applies terraform configuration"
+  terraform-init-then-plan:
+    description: "Initializes and run plan from terraform configuration"
     parameters:
       environment:
         type: string
@@ -56,13 +56,55 @@ commands:
           name: apply
           command: |
             cd ./terraform/<<parameters.environment>>/
-            terraform apply -auto-approve
+            terraform plan -out=plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+            - project/*
+  terraform-compliance:
+    description: "Run Terraform Compliance checks"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+            apk add --update --no-cache g++ gcc libxslt-dev python3-dev
+            python3 -m ensurepip
+            pip3 install --no-cache --upgrade pip setuptools
+            pip install terraform-compliance
+            terraform-compliance -f terraform-compliance/ -p plan.out
+          name: terraform compliance
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
+  terraform-apply:
+    description: "Runs Terraform Apply"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          name: apply
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform apply -auto-approve plan.out
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .aws
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:
       stage:
-        type: string
-      aws-account:
         type: string
     steps:
       - *attach_workspace
@@ -86,7 +128,9 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ContractsApi/
-            sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+            npm i serverless-associate-waf
+            npm i @serverless/safeguards-plugin --save-dev
+            sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
   check-code-formatting:
@@ -125,39 +169,66 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  terraform-init-and-apply-to-development:
+  terraform-init-and-plan-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-apply:
+      - terraform-init-then-plan:
           environment: "development"
-  terraform-init-and-apply-to-staging:
+  terraform-apply-development:
     executor: docker-terraform
     steps:
-      - terraform-init-then-apply:
+      - terraform-apply:
+          environment: "development"
+  terraform-compliance-development:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "development"
+  terraform-init-and-plan-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
           environment: "staging"
-  terraform-init-and-apply-to-production:
+  terraform-compliance-staging:
     executor: docker-terraform
     steps:
-      - terraform-init-then-apply:
+      - terraform-compliance:
+          environment: "staging"
+  terraform-apply-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "staging"
+  terraform-init-and-plan-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "production"
+  terraform-compliance-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "production"
+  terraform-apply-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
           environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
           stage: "development"
-          aws-account: $AWS_ACCOUNT_DEVELOPMENT
   deploy-to-staging:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
           stage: "staging"
-          aws-account: $AWS_ACCOUNT_STAGING
   deploy-to-production:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
           stage: "production"
-          aws-account: $AWS_ACCOUNT_PRODUCTION
 
 workflows:
   check-and-deploy-development:
@@ -172,44 +243,72 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: development
-      - terraform-init-and-apply-to-development:
+              only: master
+      - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+          filters:
+            branches:
+              only: master
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+          filters:
+            branches:
+              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
-            - terraform-init-and-apply-to-development
+            - terraform-apply-development
           filters:
             branches:
-              only: development
-#   check-and-deploy-staging-and-production:
+              only: master
+#  check-and-deploy-staging-and-production:
 #       jobs:
 #       - build-and-test:
 #           context: api-nuget-token-context
 #           filters:
 #             branches:
 #               only: master
+#       - permit-staging-terraform-release:
+#           type: approval
+#           requires:
+#             - deploy-to-development
 #       - assume-role-staging:
-#           context: api-assume-role-staging-context
+#           context: api-assume-role-housing-staging-context
 #           requires:
 #               - build-and-test
 #           filters:
 #              branches:
 #                only: master
-#       - terraform-init-and-apply-to-staging:
+#       - terraform-init-and-plan-staging:
 #           requires:
 #             - assume-role-staging
+#           filters:
+#             branches:
+#               only: master
+#       - terraform-compliance-staging:
+#           requires:
+#             - terraform-init-and-plan-staging
+#           filters:
+#             branches:
+#               only: master
+#       - terraform-apply-staging:
+#           requires:
+#             - terraform-compliance-staging
 #           filters:
 #             branches:
 #               only: master
 #       - deploy-to-staging:
 #           context: api-nuget-token-context
 #           requires:
-#             - terraform-init-and-apply-to-staging
+#             - terraform-apply-staging
 #           filters:
 #             branches:
 #               only: master
@@ -218,22 +317,34 @@ workflows:
 #           requires:
 #             - deploy-to-staging
 #       - assume-role-production:
-#           context: api-assume-role-production-context
+#           context: api-assume-role-housing-production-context
 #           requires:
 #               - permit-production-terraform-release
 #           filters:
 #              branches:
 #                only: master
-#       - terraform-init-and-apply-to-production:
+#       - terraform-init-and-plan-production:
 #           requires:
 #             - assume-role-production
+#           filters:
+#             branches:
+#               only: master
+#       - terraform-compliance-production:
+#           requires:
+#             - terraform-init-and-plan-production
+#           filters:
+#             branches:
+#               only: master
+#       - terraform-apply-production:
+#           requires:
+#             - terraform-compliance-production
 #           filters:
 #             branches:
 #               only: master
 #       - permit-production-release:
 #           type: approval
 #           requires:
-#             - deploy-to-staging
+#             - terraform-apply-production
 #           filters:
 #             branches:
 #               only: master
@@ -241,7 +352,6 @@ workflows:
 #           context: api-nuget-token-context
 #           requires:
 #             - permit-production-release
-#             - terraform-init-and-apply-to-production
 #           filters:
 #             branches:
 #               only: master


### PR DESCRIPTION
### What
This PR updates the circleCi pipeline to deploy to the lambda and respective terraform infrastructure to the AWS dev environment. 
### Why
To deploy the API to AWS so it can be used on the dev environment 
### Anything else
All the configuration has also been added for deploying to staging and production but has been commented out as the terraform is not set up for those environments. Sonarcloud will also have to be added later once the project has been setup