### PR TITLE
Add index for contracts by targetId

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -10,6 +10,14 @@ resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
         type = "S"
     }
 
+    global_secondary_index {
+        name               = "ContractsByTargetId"
+        hash_key           = "targetId"
+        write_capacity     = 10
+        read_capacity      = 10
+        projection_type    = "ALL"
+    }
+
     tags = merge(
         local.default_tags,
         { BackupPolicy = "Dev" }


### PR DESCRIPTION
## What
This PR adds an index for finding contracts by their targetId to the DynamoDb table 
## Why
To allow a quicker search for finding contracts by targetId