### PR TITLE
Feature/ht20 575 add supplier address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,32 +243,32 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: feature/HT20-575-add-supplier-address
+              only: master
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: feature/HT20-575-add-supplier-address
+              only: master
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
           filters:
             branches:
-              only: feature/HT20-575-add-supplier-address
+              only: master
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
           filters:
             branches:
-              only: feature/HT20-575-add-supplier-address
+              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
           filters:
             branches:
-              only: feature/HT20-575-add-supplier-address
+              only: master
   check-and-deploy-staging-and-production:
        jobs:
        - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,32 +243,32 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: master
+              only: feature/HT20-575-add-supplier-address
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: master
+              only: feature/HT20-575-add-supplier-address
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
           filters:
             branches:
-              only: master
+              only: feature/HT20-575-add-supplier-address
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
           filters:
             branches:
-              only: master
+              only: feature/HT20-575-add-supplier-address
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
           filters:
             branches:
-              only: master
+              only: feature/HT20-575-add-supplier-address
   check-and-deploy-staging-and-production:
        jobs:
        - check-code-formatting:

--- a/ContractsApi/V1/Domain/RelatedPeople.cs
+++ b/ContractsApi/V1/Domain/RelatedPeople.cs
@@ -13,5 +13,6 @@ namespace ContractsApi.V1.Domain
         public string Description { get; set; }
         public string Phone { get; set; }
         public string RelatedId { get; set; }
+        public string Address { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[HT20-575: Add more info about Suppliers on the Asset page in the Contract and Details sections](https://hackney.atlassian.net/browse/HT20-575)

## Describe this PR

### *What is the problem we're trying to solve*

Add an address to a contract supplier, so they are easily contactable.

### *What changes have we introduced*

Add an address field to the related person entity, which is internal to the Contracts API.


