### PR TITLE
Reinstate contracts dynamoDB table

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,4 +1,4 @@
-/* resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
+resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
     name           = "Contracts"
     billing_mode   = "PROVISIONED"
     read_capacity  = 10
@@ -31,4 +31,4 @@
     point_in_time_recovery {
         enabled = true
     }
-} */
+}

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -54,14 +54,14 @@ resource "aws_ssm_parameter" "contracts_sns_arn" {
     value = aws_sns_topic.contracts.arn
 }
 
-/* module "contracts_api_cloudwatch_dashboard" {
+module "contracts_api_cloudwatch_dashboard" {
     source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
     environment_name    = var.environment_name
     api_name            = "contracts-api"
     sns_topic_name      = aws_sns_topic.contracts.name
     dynamodb_table_name = aws_dynamodb_table.contractsapi_dynamodb_table.name
     include_sns_widget  = false
-} */
+}
 
 data "aws_ssm_parameter" "cloudwatch_topic_arn" {
     name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -1,4 +1,4 @@
-/* resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
+resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
     name           = "Contracts"
     billing_mode   = "PROVISIONED"
     read_capacity  = 10
@@ -31,4 +31,4 @@
     point_in_time_recovery {
         enabled = true
     }
-} */
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -54,14 +54,14 @@ resource "aws_ssm_parameter" "contracts_sns_arn" {
     value = aws_sns_topic.contracts.arn
 }
 
-/* module "contracts_api_cloudwatch_dashboard" {
+module "contracts_api_cloudwatch_dashboard" {
     source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
     environment_name    = var.environment_name
     api_name            = "contracts-api"
     sns_topic_name      = aws_sns_topic.contracts.name
     dynamodb_table_name = aws_dynamodb_table.contractsapi_dynamodb_table.name
     include_sns_widget  = false
-} */
+}
 
 data "aws_ssm_parameter" "cloudwatch_topic_arn" {
     name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"


### PR DESCRIPTION
### What
This PR allows the recreation of the contracts dynamoDB tables on dev and staging environments
### Why
So that the table has the new column name for `VATregistrationNumber`