### PR TITLE
Add suspension date and reason for suspension properties

### DIFF
--- a/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
+++ b/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
@@ -33,5 +33,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string OptionToTaxLinkToGoogleDrive { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
+        public DateTime? SuspensionDate { get; set; }
+        public string ReasonForSuspensionDate { get; set; }
     }
 }

--- a/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
+++ b/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
@@ -30,5 +30,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string OptionToTaxLinkToGoogleDrive { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
+        public DateTime? SuspensionDate { get; set; }
+        public string ReasonForSuspensionDate { get; set; }
     }
 }

--- a/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
+++ b/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
@@ -34,5 +34,7 @@ namespace ContractsApi.V1.Boundary.Response
         public string OptionToTaxLinkToGoogleDrive { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
+        public DateTime? SuspensionDate { get; set; }
+        public string ReasonForSuspensionDate { get; set; }
     }
 }

--- a/ContractsApi/V1/Domain/Contract.cs
+++ b/ContractsApi/V1/Domain/Contract.cs
@@ -33,5 +33,7 @@ namespace ContractsApi.V1.Domain
         public string OptionToTaxLinkToGoogleDrive { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
+        public DateTime? SuspensionDate { get; set; }
+        public string ReasonForSuspensionDate { get; set; }
     }
 }

--- a/ContractsApi/V1/Factories/CreateRequestFactory.cs
+++ b/ContractsApi/V1/Factories/CreateRequestFactory.cs
@@ -39,7 +39,9 @@ namespace ContractsApi.V1.Factories
                 OptionToTax = request.OptionToTax,
                 OptionToTaxLinkToGoogleDrive = request.OptionToTaxLinkToGoogleDrive,
                 Rates = request.Rates,
-                DefaultTenureType = request.DefaultTenureType
+                DefaultTenureType = request.DefaultTenureType,
+                SuspensionDate = request.SuspensionDate,
+                ReasonForSuspensionDate = request.ReasonForSuspensionDate
             };
         }
     }

--- a/ContractsApi/V1/Factories/EntityFactory.cs
+++ b/ContractsApi/V1/Factories/EntityFactory.cs
@@ -38,7 +38,9 @@ namespace ContractsApi.V1.Factories
                 OptionToTax = contractDb.OptionToTax,
                 OptionToTaxLinkToGoogleDrive = contractDb.OptionToTaxLinkToGoogleDrive,
                 Rates = contractDb.Rates,
-                DefaultTenureType = contractDb.DefaultTenureType
+                DefaultTenureType = contractDb.DefaultTenureType,
+                SuspensionDate = contractDb.SuspensionDate,
+                ReasonForSuspensionDate = contractDb.ReasonForSuspensionDate
             };
         }
 
@@ -74,7 +76,9 @@ namespace ContractsApi.V1.Factories
                 OptionToTax = contract.OptionToTax,
                 OptionToTaxLinkToGoogleDrive = contract.OptionToTaxLinkToGoogleDrive,
                 Rates = contract.Rates,
-                DefaultTenureType = contract.DefaultTenureType
+                DefaultTenureType = contract.DefaultTenureType,
+                SuspensionDate = contract.SuspensionDate,
+                ReasonForSuspensionDate = contract.ReasonForSuspensionDate
             };
         }
     }

--- a/ContractsApi/V1/Factories/ResponseFactory.cs
+++ b/ContractsApi/V1/Factories/ResponseFactory.cs
@@ -39,7 +39,9 @@ namespace ContractsApi.V1.Factories
                 OptionToTax = contract.OptionToTax,
                 OptionToTaxLinkToGoogleDrive = contract.OptionToTaxLinkToGoogleDrive,
                 Rates = contract.Rates,
-                DefaultTenureType = contract.DefaultTenureType
+                DefaultTenureType = contract.DefaultTenureType,
+                SuspensionDate = contract.SuspensionDate,
+                ReasonForSuspensionDate = contract.ReasonForSuspensionDate
             };
         }
 

--- a/ContractsApi/V1/Infrastructure/ContractsDb.cs
+++ b/ContractsApi/V1/Infrastructure/ContractsDb.cs
@@ -77,5 +77,9 @@ namespace ContractsApi.V1.Infrastructure
 
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<TenureType>))]
         public TenureType DefaultTenureType { get; set; }
+        [DynamoDBProperty]
+        public DateTime? SuspensionDate { get; set; }
+        [DynamoDBProperty]
+        public string ReasonForSuspensionDate { get; set; }
     }
 }


### PR DESCRIPTION
### What
This PR adds two new properties to contracts:

- `SuspensionDate`
- `ReasonForSuspensionDate`

### Why
To record when and why contract payments have been suspended.