### PR TITLE
Don't validate against start date if it's not included in the request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,32 +243,32 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: feature/HT20-722-handback-validation
+              only: master
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: feature/HT20-722-handback-validation
+              only: master
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
           filters:
             branches:
-              only: feature/HT20-722-handback-validation
+              only: master
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
           filters:
             branches:
-              only: feature/HT20-722-handback-validation
+              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
           filters:
             branches:
-              only: feature/HT20-722-handback-validation
+              only: master
   check-and-deploy-staging-and-production:
        jobs:
        - check-code-formatting:


### PR DESCRIPTION
## Link to JIRA ticket

[Backend: Add End Contract functionality to property page.](https://hackney.atlassian.net/browse/HT20-722)

## Describe this PR

### *What is the problem we're trying to solve*

Don't validate handback date against start date, via fluent validation if either of start date or handback date are not supplied on the request.

### *What changes have we introduced*

Tweak the validation rules to include a When case


