### PR TITLE
HT20-722: Date validation in gateway

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty
+* @lbhmenks @Miles-Alford

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -206,17 +206,47 @@ namespace ContractsApi.Tests.V1.Gateways
 
             response.Should().BeNull();
         }
+        [Fact]
+        public async Task PatchContractThrowsDatesError()
+        {
+            var today = DateTime.Today;
+            var tomorrow = today.AddDays(1);
+            var currentContract = _fixture.Build<ContractDb>()
+                                .With(x => x.StartDate, (DateTime?) tomorrow)
+                                .With(x => x.VersionNumber, (int?) null).Create();
+
+            await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
+
+            var contractId = currentContract.Id;
+            var request = _fixture.Create<EditContractRequest>();
+            request.HandbackDate = today;
+
+            Func<Task<UpdateEntityResult<ContractDb>>> func = async () =>
+                await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), It.IsAny<int>())
+                    .ConfigureAwait(false);
+
+            await func.Should().ThrowAsync<StartAndHandbackDatesConflictException>().WithMessage($"Handback date ({request.HandbackDate}) cannot be prior to Start date ({currentContract.StartDate}).");
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}", Times.Never());
+        }
+
+
 
         [Fact]
         public async Task PatchContractThrowsConflictVersionError()
         {
-            var currentContract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).Create();
+            var today = DateTime.Today;
+            var tomorrow = today.AddDays(1);
+            var currentContract = _fixture.Build<ContractDb>()
+                .With(x => x.VersionNumber, (int?) null)
+                .With(x => x.StartDate, (DateTime?) today)
+                .Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
 
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
             var suppliedVersion = 1;
+            request.HandbackDate = tomorrow;
 
             Func<Task<UpdateEntityResult<ContractDb>>> func = async () =>
                 await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), suppliedVersion)
@@ -229,12 +259,18 @@ namespace ContractsApi.Tests.V1.Gateways
         [Fact]
         public async Task PatchContractSuccessfullyUpdatesAContract()
         {
-            var currentContract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).Create();
+            var today = DateTime.Today;
+            var tomorrow = today.AddDays(1);
+            var currentContract = _fixture.Build<ContractDb>()
+                .With(x => x.VersionNumber, (int?) null)
+                .With(x => x.StartDate, (DateTime?) today)
+                .Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
 
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
+            request.HandbackDate = tomorrow;
             var requestBody = "{ \"StartDate\":\"key7d2d6e42-0cbf-411a-b66c-bc35da8b6061\":{ },\"EndDate\":\"89017f11-95f7-434d-96f8-178e33685fb4\"}}";
             var suppliedVersion = 0;
 

--- a/ContractsApi/V1/Controllers/ContractsApiController.cs
+++ b/ContractsApi/V1/Controllers/ContractsApiController.cs
@@ -133,6 +133,10 @@ namespace ContractsApi.V1.Controllers
             {
                 return Conflict(e.Message);
             }
+            catch (StartAndHandbackDatesConflictException e)
+            {
+                return Conflict(e.Message);
+            }
         }
 
         private int? GetIfMatchFromHeader()

--- a/ContractsApi/V1/Gateways/DynamoDbGateway.cs
+++ b/ContractsApi/V1/Gateways/DynamoDbGateway.cs
@@ -149,6 +149,9 @@ namespace ContractsApi.V1.Gateways
             if (ifMatch != existingContract.VersionNumber)
                 throw new VersionNumberConflictException(ifMatch, existingContract.VersionNumber);
 
+            if (existingContract.StartDate > contractRequestBody.HandbackDate)
+                throw new StartAndHandbackDatesConflictException(existingContract.StartDate, contractRequestBody.HandbackDate);
+
             var response = _updater.UpdateEntity(existingContract, requestBody, contractRequestBody);
 
             if (response.NewValues.Any())

--- a/ContractsApi/V1/Infrastructure/Exceptions/StartAndHandbackDatesConflictException.cs
+++ b/ContractsApi/V1/Infrastructure/Exceptions/StartAndHandbackDatesConflictException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace ContractsApi.V1.Infrastructure.Exceptions
+{
+    public class StartAndHandbackDatesConflictException : Exception
+    {
+        public DateTime? ContractStartDate { get; private set; }
+        public DateTime? ContractHandbackDate { get; private set; }
+
+        public StartAndHandbackDatesConflictException(DateTime? startDate, DateTime? handbackDate)
+            : base(string.Format("Handback date ({1}) cannot be prior to Start date ({0}).",
+                (startDate is null) ? "{null}" : startDate.ToString(),
+                (handbackDate is null) ? "{null}" : handbackDate.ToString()))
+        {
+            ContractStartDate = startDate;
+            ContractHandbackDate = handbackDate;
+        }
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/HT20-722

## Describe this PR

### *What is the problem we're trying to solve*

On top of the FluentValidation for the PATCH request, this introduces a similar validation on `StartDate` vs `HandbackDate` on the gateway. This is to make sure the Handback date is not in conflict with the preexisting Start date.