### PR TITLE
Feature/ts 1204 - Add group-based security to the contracts API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,32 +243,32 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: feature/TS-1204
+              only: master
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: feature/TS-1204
+              only: master
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
           filters:
             branches:
-              only: feature/TS-1204
+              only: master
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
           filters:
             branches:
-              only: feature/TS-1204
+              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
           filters:
             branches:
-              only: feature/TS-1204
+              only: master
   check-and-deploy-staging-and-production:
        jobs:
        - check-code-formatting:


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1204: Add security to the contracts API](https://hackney.atlassian.net/browse/TS-1204)

## Describe this PR

### *What is the problem we're trying to solve*

Add group-based security to the contracts API, modelled after our other live APIs eg. Tenure

### *What changes have we introduced*

Deploy an authorizer configuration for the contracts API lambda.

### *Follow up actions after merging PR*

The databases are configured for `mmh-project-team`, but should really be using a new role eg. `ta-users`. We also need to audit the "standard" groups eg. `saml-aws-mtfh-developer` and see if they are still relevant


[TS-1204]: https://hackney.atlassian.net/browse/TS-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ