### PR TITLE
Cap the serverless version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# LBH Base API
-[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=LBHackney-IT_contracts-api)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=bugs)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
@@ -7,6 +6,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+# LBH Base API
 
 Base API is a boilerplate code for being reused for new APIs for LBH
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # LBH Base API
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=LBHackney-IT_contracts-api)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=bugs)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 
 Base API is a boilerplate code for being reused for new APIs for LBH
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# LBH Base API
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=bugs)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
@@ -6,7 +7,6 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=LBHackney-IT_contracts-api&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=LBHackney-IT_contracts-api)
-# LBH Base API
 
 Base API is a boilerplate code for being reused for new APIs for LBH
 


### PR DESCRIPTION
## Describe this PR
- tweak serverless version
- adds sonar badges to the repo

### *What is the problem we're trying to solve*
 - The serverless v4 is still in beta, plus requires a paid license.
 
See [PR](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/140) & slack [message](https://hackit-lbh.slack.com/archives/CKR1DBEQM/p1716972437615219) for more context.


<img width="1273" alt="Screenshot 2024-06-21 at 10 21 04" src="https://github.com/LBHackney-IT/contracts-api/assets/54672259/734f5882-42f2-4c63-9a21-4b70a6b03978">
