### PR TITLE
Ts 1610

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @Miles-Alford @LBHTKarki @martapederiva @sam-drumm @1JW1
+* @Miles-Alford @LBHTKarki @martapederiva @sam-drumm @1JW1 @LBHJHeppinstall

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk
 #  && apk upgrade --no-cache \
 #  && apk add --no-cache openjdk-17-jdk
 
-#RUN dotnet tool install --global dotnet-sonarscanner
+RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-#RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./ContractsApi.sln ./
@@ -41,4 +41,4 @@ RUN dotnet build -c debug -o out ContractsApi.Tests/ContractsApi.Tests.csproj
 
 CMD dotnet test
 
-#RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk
 #  && apk upgrade --no-cache \
 #  && apk add --no-cache openjdk-17-jdk
 
-RUN dotnet tool install --global dotnet-sonarscanner
+#RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+#RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./ContractsApi.sln ./
@@ -41,4 +41,4 @@ RUN dotnet build -c debug -o out ContractsApi.Tests/ContractsApi.Tests.csproj
 
 CMD dotnet test
 
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+#RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
+++ b/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
@@ -22,6 +22,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? HoldPayment { get; set; }
         public bool? IsVATRegistered { get; set; }
         public int? Stage { get; set; }

--- a/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
+++ b/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
@@ -19,6 +19,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? HoldPayment { get; set; }
         public bool? IsVATRegistered { get; set; }
         public int? Stage { get; set; }

--- a/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
+++ b/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
@@ -25,6 +25,7 @@ namespace ContractsApi.V1.Boundary.Response
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? HoldPayment { get; set; }
         public bool? IsVATRegistered { get; set; }
         public int? Stage { get; set; }

--- a/ContractsApi/V1/Domain/Contract.cs
+++ b/ContractsApi/V1/Domain/Contract.cs
@@ -24,6 +24,7 @@ namespace ContractsApi.V1.Domain
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public bool? HoldPayment { get; set; }
         public bool? IsVATRegistered { get; set; }
         public int? Stage { get; set; }

--- a/ContractsApi/V1/Domain/Enums.cs
+++ b/ContractsApi/V1/Domain/Enums.cs
@@ -11,4 +11,12 @@ namespace ContractsApi.V1.Domain
         Monthly,
         Yearly
     }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ApprovalStatus
+    {
+        PendingApproval,
+        Approved,
+        PendingReapproval
+    }
 }

--- a/ContractsApi/V1/Factories/CreateRequestFactory.cs
+++ b/ContractsApi/V1/Factories/CreateRequestFactory.cs
@@ -26,6 +26,7 @@ namespace ContractsApi.V1.Factories
                 Brma = request.Brma,
                 IsActive = request.IsActive,
                 IsApproved = request.IsApproved,
+                ApprovalStatus = request.ApprovalStatus,
                 HoldPayment = request.HoldPayment,
                 IsVATRegistered = request.IsVATRegistered,
                 Stage = request.Stage,

--- a/ContractsApi/V1/Factories/EntityFactory.cs
+++ b/ContractsApi/V1/Factories/EntityFactory.cs
@@ -29,6 +29,7 @@ namespace ContractsApi.V1.Factories
                 Brma = contractDb.Brma,
                 IsActive = contractDb.IsActive,
                 IsApproved = contractDb.IsApproved,
+                ApprovalStatus = contractDb.ApprovalStatus,
                 HoldPayment = contractDb.HoldPayment,
                 IsVATRegistered = contractDb.IsVATRegistered,
                 Stage = contractDb.Stage,

--- a/ContractsApi/V1/Factories/EntityFactory.cs
+++ b/ContractsApi/V1/Factories/EntityFactory.cs
@@ -69,6 +69,7 @@ namespace ContractsApi.V1.Factories
                 Brma = contract.Brma,
                 IsActive = contract.IsActive,
                 IsApproved = contract.IsApproved,
+                ApprovalStatus = contract.ApprovalStatus,
                 IsVATRegistered = contract.IsVATRegistered,
                 Stage = contract.Stage,
                 VatRegistrationNumber = contract.VatRegistrationNumber,

--- a/ContractsApi/V1/Factories/ResponseFactory.cs
+++ b/ContractsApi/V1/Factories/ResponseFactory.cs
@@ -26,6 +26,7 @@ namespace ContractsApi.V1.Factories
                 Brma = contract.Brma,
                 IsActive = contract.IsActive,
                 IsApproved = contract.IsApproved,
+                ApprovalStatus = contract.ApprovalStatus,
                 HoldPayment = contract.HoldPayment,
                 IsVATRegistered = contract.IsVATRegistered,
                 Stage = contract.Stage,

--- a/ContractsApi/V1/Infrastructure/ContractsDb.cs
+++ b/ContractsApi/V1/Infrastructure/ContractsDb.cs
@@ -50,45 +50,64 @@ namespace ContractsApi.V1.Infrastructure
 
         [DynamoDBVersion]
         public int? VersionNumber { get; set; }
+
         [DynamoDBProperty]
         public string CostCentre { get; set; }
+
         [DynamoDBProperty]
         public string Brma { get; set; }
+
         [DynamoDBProperty]
         public bool? IsActive { get; set; }
+
         [DynamoDBProperty]
         public bool? IsApproved { get; set; }
+
         [DynamoDBProperty]
         public ApprovalStatus ApprovalStatus { get; set; }
+
         [DynamoDBProperty]
         public bool? HoldPayment { get; set; }
+
         [DynamoDBProperty]
         public bool? IsVATRegistered { get; set; }
+
         [DynamoDBProperty]
         public int? Stage { get; set; }
+
         [DynamoDBProperty]
         public string VatRegistrationNumber { get; set; }
+
         [DynamoDBProperty]
         public DateTime? ReviewDate { get; set; }
+
         [DynamoDBProperty]
         public DateTime? ExtensionDate { get; set; }
+
         [DynamoDBProperty]
         public string ReasonForExtensionDate { get; set; }
+
         [DynamoDBProperty]
         public bool? SelfBillingAgreement { get; set; }
+
         [DynamoDBProperty]
         public string SelfBillingAgreementLinkToGoogleDrive { get; set; }
+
         [DynamoDBProperty]
         public bool? OptionToTax { get; set; }
+
         [DynamoDBProperty]
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+
         [DynamoDBProperty]
         public Frequency Rates { get; set; }
 
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectConverter<TenureType>))]
         public TenureType DefaultTenureType { get; set; }
+
         [DynamoDBProperty]
         public DateTime? SuspensionDate { get; set; }
+
         [DynamoDBProperty]
         public string ReasonForSuspensionDate { get; set; }
     }

--- a/ContractsApi/V1/Infrastructure/ContractsDb.cs
+++ b/ContractsApi/V1/Infrastructure/ContractsDb.cs
@@ -59,6 +59,8 @@ namespace ContractsApi.V1.Infrastructure
         [DynamoDBProperty]
         public bool? IsApproved { get; set; }
         [DynamoDBProperty]
+        public ApprovalStatus ApprovalStatus { get; set; }
+        [DynamoDBProperty]
         public bool? HoldPayment { get; set; }
         [DynamoDBProperty]
         public bool? IsVATRegistered { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1610

## Describe this PR

### *What is the problem we're trying to solve*

BTA users want to be able to reset the contract approval status of an updated approved contract so that it can be submitted for reapproval. This calls for changing from a boolean value to an enum, to account for more than two possible statuses.
We haven't removed the `isApproved` flag yet so that the FE can continue to function until we introduce the new field there too.

### *What changes have we introduced*

New field.

### *Follow up actions after merging PR*

The Housing Search API/ecosystem needs to be updated, as well as the FE.