### PR TITLE
Bug ts1727

### DIFF
--- a/ContractsApi.Tests/ContractsApi.Tests.csproj
+++ b/ContractsApi.Tests/ContractsApi.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.401.13" />
     <PackageReference Include="DeepCloner" Version="0.10.4" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.73.0-feat-patch-api-g0004" />

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk
 #  && apk upgrade --no-cache \
 #  && apk add --no-cache openjdk-17-jdk
 
-RUN dotnet tool install --global dotnet-sonarscanner
-ENV PATH="$PATH:/root/.dotnet/tools"
+# RUN dotnet tool install --global dotnet-sonarscanner
+# ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+# RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./ContractsApi.sln ./
@@ -41,4 +41,4 @@ RUN dotnet build -c debug -o out ContractsApi.Tests/ContractsApi.Tests.csproj
 
 CMD dotnet test
 
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+# RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk
 #  && apk upgrade --no-cache \
 #  && apk add --no-cache openjdk-17-jdk
 
- RUN dotnet tool install --global dotnet-sonarscanner
- ENV PATH="$PATH:/root/.dotnet/tools"
+RUN dotnet tool install --global dotnet-sonarscanner
+ENV PATH="$PATH:/root/.dotnet/tools"
 
- RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./ContractsApi.sln ./
@@ -41,4 +41,4 @@ RUN dotnet build -c debug -o out ContractsApi.Tests/ContractsApi.Tests.csproj
 
 CMD dotnet test
 
- RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk
 #  && apk upgrade --no-cache \
 #  && apk add --no-cache openjdk-17-jdk
 
-# RUN dotnet tool install --global dotnet-sonarscanner
-# ENV PATH="$PATH:/root/.dotnet/tools"
+ RUN dotnet tool install --global dotnet-sonarscanner
+ ENV PATH="$PATH:/root/.dotnet/tools"
 
-# RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+ RUN dotnet sonarscanner begin /k:"LBHackney-IT_contracts-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./ContractsApi.sln ./
@@ -41,4 +41,4 @@ RUN dotnet build -c debug -o out ContractsApi.Tests/ContractsApi.Tests.csproj
 
 CMD dotnet test
 
-# RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+ RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -1,16 +1,18 @@
+using System;
+using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DataModel;
 using AutoFixture;
 using ContractsApi.V1.Domain;
-using ContractsApi.V1.Gateways;
 using ContractsApi.V1.Infrastructure;
 using FluentAssertions;
-using Hackney.Core.Testing.Shared;
-using Microsoft.Extensions.Logging;
-using Moq;
-using System;
+using Xunit;
 using System.Collections.Generic;
+using Amazon.DynamoDBv2.Model;
+using Moq;
+using Microsoft.Extensions.Logging;
+using ContractsApi.V1.Gateways;
+using Hackney.Core.Testing.Shared;
 using System.Linq;
-using System.Threading.Tasks;
 using ContractsApi.Tests.V1.Helper;
 using ContractsApi.V1.Boundary.Requests;
 using ContractsApi.V1.Factories;
@@ -18,7 +20,6 @@ using ContractsApi.V1.Infrastructure.Exceptions;
 using Force.DeepCloner;
 using Hackney.Core.JWT;
 using Hackney.Core.Testing.DynamoDb;
-using Xunit;
 
 namespace ContractsApi.Tests.V1.Gateways
 {
@@ -70,6 +71,7 @@ namespace ContractsApi.Tests.V1.Gateways
                 .With(x => x.TargetType, "asset")
                 .With(x => x.VersionNumber, (int?) null)
                 .With(x => x.HandbackDate, (DateTime?) null)
+                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
                 .CreateMany(count));
 
             foreach (var contract in contracts)
@@ -95,6 +97,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var contract = _fixture.Build<ContractDb>()
                 .With(x => x.VersionNumber, (int?) null)
+                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
                 .Create();
 
             await InsertDataIntoDynamoDB(contract).ConfigureAwait(false);
@@ -286,6 +289,7 @@ namespace ContractsApi.Tests.V1.Gateways
             var currentContract = _fixture.Build<ContractDb>()
                 .With(x => x.VersionNumber, (int?) null)
                 .With(x => x.StartDate, (DateTime?) today)
+                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
                 .Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
@@ -324,6 +328,30 @@ namespace ContractsApi.Tests.V1.Gateways
             load.EndDate.Should().Be(request.EndDate);
 
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contractId).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ApprovalStatusStoredCorrectly()
+        {
+            //using triple A XD
+
+            // Arrange
+            var contract = _fixture.Build<ContractDb>()
+                .With(x => x.VersionNumber, (int?)null)
+                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
+                .Create();
+            // Act
+            await _classUnderTest.PostNewContractAsync(contract).ConfigureAwait(false);
+            var storedContract = await _dbFixture.DynamoDbContext.LoadAsync<ContractDb>(contract.Id).ConfigureAwait(false);
+            // Assert
+            storedContract.Should().NotBeNull();
+            storedContract.ApprovalStatus.Should().Be(ApprovalStatus.PendingApproval);
+            var document = _dbFixture.DynamoDbContext.ToDocument(storedContract);
+            var approvalStatusAttribute= document["ApprovalStatus"];
+            approvalStatusAttribute.Should().NotBeNull();
+            approvalStatusAttribute.AsString().Should().Be("PendingApproval");
+            // Cleanup
+            await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contract.Id).ConfigureAwait(false);
         }
     }
 }

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -185,6 +185,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var contract = _fixture.Build<ContractDb>()
                 .With(x => x.VersionNumber, (int?) null)
+                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
                 .Create();
 
             await InsertDataIntoDynamoDB(contract).ConfigureAwait(false);
@@ -192,6 +193,9 @@ namespace ContractsApi.Tests.V1.Gateways
 
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(contract.ToDomain());
+
+            var storedContract = await _dbFixture.DynamoDbContext.LoadAsync<ContractDb>(contract.Id).ConfigureAwait(false);
+            storedContract.ApprovalStatus.Should().Be(ApprovalStatus.PendingApproval);
 
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contract.Id).ConfigureAwait(false);
         }

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -192,8 +192,6 @@ namespace ContractsApi.Tests.V1.Gateways
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(contract.ToDomain());
 
-            var storedContract = await _dbFixture.DynamoDbContext.LoadAsync<ContractDb>(contract.Id).ConfigureAwait(false);
-
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contract.Id).ConfigureAwait(false);
         }
 
@@ -366,7 +364,7 @@ namespace ContractsApi.Tests.V1.Gateways
             //Assert
             var approvalStatusAttribute= document["approvalStatus"];
             approvalStatusAttribute.Should().NotBeNull();
-            approvalStatusAttribute.AsString().Should().Be("PendingApproval");
+            approvalStatusAttribute.Should().Be("PendingApproval");
         }
     }
 }

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -23,7 +23,6 @@ using Hackney.Core.Testing.DynamoDb;
 
 namespace ContractsApi.Tests.V1.Gateways
 {
-
     [Collection("AppTest collection")]
     public class DynamoDbGatewayTests : IDisposable
     {
@@ -49,6 +48,7 @@ namespace ContractsApi.Tests.V1.Gateways
         }
 
         private bool _disposed;
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing && !_disposed)
@@ -66,13 +66,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var contracts = new List<ContractDb>();
 
-            contracts.AddRange(_fixture.Build<ContractDb>()
-                .With(x => x.TargetId, targetId)
-                .With(x => x.TargetType, "asset")
-                .With(x => x.VersionNumber, (int?) null)
-                .With(x => x.HandbackDate, (DateTime?) null)
-                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
-                .CreateMany(count));
+            contracts.AddRange(_fixture.Build<ContractDb>().With(x => x.TargetId, targetId).With(x => x.TargetType, "asset").With(x => x.VersionNumber, (int?) null).With(x => x.HandbackDate, (DateTime?) null).With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval).CreateMany(count));
 
             foreach (var contract in contracts)
             {
@@ -89,23 +83,20 @@ namespace ContractsApi.Tests.V1.Gateways
             var response = await _classUnderTest.GetContractById(request).ConfigureAwait(false);
 
             response.Should().BeNull();
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id {request.Id}", Times.Once());
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id {request.Id}",
+                Times.Once());
         }
 
         [Fact]
         public async Task GetContractByIdReturnsContractIfItExists()
         {
-            var contract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?) null)
-                .Create();
-
+            var contract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).Create();
             await InsertDataIntoDynamoDB(contract).ConfigureAwait(false);
-
             var request = BoundaryHelper.ConstructRequest(contract.Id);
             var response = await _classUnderTest.GetContractById(request).ConfigureAwait(false);
-
             response.Should().BeEquivalentTo(contract);
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id {request.Id}", Times.Once());
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id {request.Id}",
+                Times.Once());
         }
 
         [Fact]
@@ -113,9 +104,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var id = Guid.NewGuid();
             var request = new GetContractsQueryRequest { TargetId = id, TargetType = "asset" };
-
             var response = await _classUnderTest.GetContractsByTargetId(request).ConfigureAwait(false);
-
             response.Should().NotBeNull();
             response.Results.Should().BeEmpty();
             response.PaginationDetails.HasNext.Should().BeFalse();
@@ -128,9 +117,7 @@ namespace ContractsApi.Tests.V1.Gateways
             var id = Guid.NewGuid();
             var request = new GetContractsQueryRequest { TargetId = id, TargetType = "asset" };
             var contracts = UpsertContracts(id, 5);
-
             var response = await _classUnderTest.GetContractsByTargetId(request).ConfigureAwait(false);
-
             response.Should().NotBeNull();
             response.Results.Should().BeEquivalentTo(contracts);
             response.PaginationDetails.HasNext.Should().BeFalse();
@@ -182,16 +169,11 @@ namespace ContractsApi.Tests.V1.Gateways
         [Fact]
         public async Task PostNewContractAsyncAddsContractToDatabase()
         {
-            var contract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?) null)
-                .Create();
-
+            var contract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).Create();
             await InsertDataIntoDynamoDB(contract).ConfigureAwait(false);
             var response = await _classUnderTest.PostNewContractAsync(contract).ConfigureAwait(false);
-
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(contract.ToDomain());
-
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contract.Id).ConfigureAwait(false);
         }
 
@@ -201,24 +183,17 @@ namespace ContractsApi.Tests.V1.Gateways
             var mockGuid = new Guid();
             var mockRequestObject = _fixture.Create<EditContractRequest>();
             var mockRawBody = "";
-
-            var response = await _classUnderTest
-                .PatchContract(mockGuid, mockRequestObject, mockRawBody, It.IsAny<int?>())
-                .ConfigureAwait(false);
-
+            var response = await _classUnderTest.PatchContract(mockGuid, mockRequestObject, mockRawBody, It.IsAny<int?>()).ConfigureAwait(false);
             response.Should().BeNull();
         }
+
         [Fact]
         public async Task PatchContractThrowsDatesError()
         {
             var today = DateTime.Today;
             var tomorrow = today.AddDays(1);
-            var currentContract = _fixture.Build<ContractDb>()
-                                .With(x => x.StartDate, (DateTime?) tomorrow)
-                                .With(x => x.VersionNumber, (int?) null).Create();
-
+            var currentContract = _fixture.Build<ContractDb>().With(x => x.StartDate, (DateTime?) tomorrow).With(x => x.VersionNumber, (int?) null).Create();
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
-
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
             request.HandbackDate = today;
@@ -227,8 +202,10 @@ namespace ContractsApi.Tests.V1.Gateways
                 await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), It.IsAny<int>())
                     .ConfigureAwait(false);
 
-            await func.Should().ThrowAsync<StartAndHandbackDatesConflictException>().WithMessage($"Handback date ({request.HandbackDate}) cannot be prior to Start date ({currentContract.StartDate}).");
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}", Times.Never());
+            await func.Should().ThrowAsync<StartAndHandbackDatesConflictException>().WithMessage(
+                $"Handback date ({request.HandbackDate}) cannot be prior to Start date ({currentContract.StartDate}).");
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}",
+                Times.Never());
         }
 
         [Fact]
@@ -236,9 +213,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var today = DateTime.Today;
             var tomorrow = today.AddDays(1);
-            var currentContract = _fixture.Build<ContractDb>()
-                                .With(x => x.StartDate, (DateTime?) null)
-                                .With(x => x.VersionNumber, (int?) null).Create();
+            var currentContract = _fixture.Build<ContractDb>().With(x => x.StartDate, (DateTime?) null).With(x => x.VersionNumber, (int?) null).Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
 
@@ -247,11 +222,11 @@ namespace ContractsApi.Tests.V1.Gateways
             request.HandbackDate = today;
 
             Func<Task<UpdateEntityResult<ContractDb>>> func = async () =>
-                await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), It.IsAny<int>())
-                    .ConfigureAwait(false);
+                await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), It.IsAny<int>()).ConfigureAwait(false);
 
             await func.Should().ThrowAsync<StartAndHandbackDatesConflictException>().WithMessage($"Handback date ({request.HandbackDate}) cannot be prior to Start date ({{null}}).");
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}", Times.Never());
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}",
+                Times.Never());
         }
 
 
@@ -260,10 +235,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var today = DateTime.Today;
             var tomorrow = today.AddDays(1);
-            var currentContract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?) null)
-                .With(x => x.StartDate, (DateTime?) today)
-                .Create();
+            var currentContract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).With(x => x.StartDate, (DateTime?) today).Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
 
@@ -273,11 +245,11 @@ namespace ContractsApi.Tests.V1.Gateways
             request.HandbackDate = tomorrow;
 
             Func<Task<UpdateEntityResult<ContractDb>>> func = async () =>
-                await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), suppliedVersion)
-                    .ConfigureAwait(false);
+                await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), suppliedVersion).ConfigureAwait(false);
 
             await func.Should().ThrowAsync<VersionNumberConflictException>().WithMessage($"The version number supplied ({suppliedVersion}) does not match the current value on the entity ({0}).");
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}", Times.Never());
+            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}",
+                Times.Never());
         }
 
         [Fact]
@@ -285,10 +257,7 @@ namespace ContractsApi.Tests.V1.Gateways
         {
             var today = DateTime.Today;
             var tomorrow = today.AddDays(1);
-            var currentContract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?) null)
-                .With(x => x.StartDate, (DateTime?) today)
-                .Create();
+            var currentContract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).With(x => x.StartDate, (DateTime?) today).Create();
 
             await InsertDataIntoDynamoDB(currentContract).ConfigureAwait(false);
 
@@ -317,14 +286,10 @@ namespace ContractsApi.Tests.V1.Gateways
                     }
                 });
 
-
             var response = await _classUnderTest.PatchContract(contractId, request, requestBody, suppliedVersion).ConfigureAwait(false);
-
             var load = await _dbFixture.DynamoDbContext.LoadAsync<ContractDb>(contractId).ConfigureAwait(false);
-
             load.StartDate.Should().Be(request.StartDate);
             load.EndDate.Should().Be(request.EndDate);
-
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contractId).ConfigureAwait(false);
         }
 
@@ -332,19 +297,13 @@ namespace ContractsApi.Tests.V1.Gateways
         public async Task ApprovalStatusStoredAndRetrievedCorrectly()
         {
             // Arrange
-            var contract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?)null)
-                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
-                .Create();
-
+            var contract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval).Create();
             // Act
             await _classUnderTest.PostNewContractAsync(contract).ConfigureAwait(false);
-
             // Assert
             var storedContract = await _dbFixture.DynamoDbContext.LoadAsync<ContractDb>(contract.Id).ConfigureAwait(false);
             storedContract.Should().NotBeNull();
             storedContract.ApprovalStatus.Should().Be(ApprovalStatus.PendingApproval);
-
             // Cleanup
             await _dbFixture.DynamoDbContext.DeleteAsync<ContractDb>(contract.Id).ConfigureAwait(false);
         }
@@ -353,16 +312,11 @@ namespace ContractsApi.Tests.V1.Gateways
         public void ApprovalStatusStoredAsStringInDynamoDb()
         {
             // Arrange
-            var contract = _fixture.Build<ContractDb>()
-                .With(x => x.VersionNumber, (int?)null)
-                .With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval)
-                .Create();
-
+            var contract = _fixture.Build<ContractDb>().With(x => x.VersionNumber, (int?) null).With(x => x.ApprovalStatus, ApprovalStatus.PendingApproval).Create();
             //Act
             var document = _dbFixture.DynamoDbContext.ToDocument(contract);
-
             //Assert
-            var approvalStatusAttribute= document["approvalStatus"];
+            var approvalStatusAttribute = document["approvalStatus"];
             approvalStatusAttribute.Should().NotBeNull();
             approvalStatusAttribute.ToString().Should().Be("PendingApproval");
         }

--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -364,7 +364,7 @@ namespace ContractsApi.Tests.V1.Gateways
             //Assert
             var approvalStatusAttribute= document["approvalStatus"];
             approvalStatusAttribute.Should().NotBeNull();
-            approvalStatusAttribute.Should().Be("PendingApproval");
+            approvalStatusAttribute.ToString().Should().Be("PendingApproval");
         }
     }
 }

--- a/ContractsApi/ContractsApi.csproj
+++ b/ContractsApi/ContractsApi.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="5.1.1" />
     <PackageReference Include="AspectInjector" Version="2.5.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.21" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.401.13" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="AWSXRayRecorder.Core" Version="2.10.0" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />

--- a/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
+++ b/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
@@ -23,7 +23,6 @@ namespace ContractsApi.V1.Boundary.Requests
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool IsApproved { get; set; }
-        public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? HoldPayment { get; set; }
         public int? Stage { get; set; }
@@ -35,6 +34,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string SelfBillingAgreementLinkToGoogleDrive { get; set; }
         public bool? OptionToTax { get; set; }
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }

--- a/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
+++ b/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
@@ -20,7 +20,6 @@ namespace ContractsApi.V1.Boundary.Requests
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
-        public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? HoldPayment { get; set; }
         public int? Stage { get; set; }
@@ -32,6 +31,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public string SelfBillingAgreementLinkToGoogleDrive { get; set; }
         public bool? OptionToTax { get; set; }
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }

--- a/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
+++ b/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
@@ -26,7 +26,6 @@ namespace ContractsApi.V1.Boundary.Response
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
-        public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? HoldPayment { get; set; }
         public int? Stage { get; set; }
@@ -38,6 +37,7 @@ namespace ContractsApi.V1.Boundary.Response
         public string SelfBillingAgreementLinkToGoogleDrive { get; set; }
         public bool? OptionToTax { get; set; }
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }

--- a/ContractsApi/V1/Domain/Contract.cs
+++ b/ContractsApi/V1/Domain/Contract.cs
@@ -25,7 +25,6 @@ namespace ContractsApi.V1.Domain
         public string Brma { get; set; }
         public bool? IsActive { get; set; }
         public bool? IsApproved { get; set; }
-        public ApprovalStatus ApprovalStatus { get; set; }
         public string ApprovalStatusReason { get; set; }
         public bool? HoldPayment { get; set; }
         public int? Stage { get; set; }
@@ -37,6 +36,7 @@ namespace ContractsApi.V1.Domain
         public string SelfBillingAgreementLinkToGoogleDrive { get; set; }
         public bool? OptionToTax { get; set; }
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+        public ApprovalStatus ApprovalStatus { get; set; }
         public Frequency Rates { get; set; }
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }

--- a/ContractsApi/V1/Infrastructure/ContractsDb.cs
+++ b/ContractsApi/V1/Infrastructure/ContractsDb.cs
@@ -67,9 +67,6 @@ namespace ContractsApi.V1.Infrastructure
         public bool? IsApproved { get; set; }
 
         [DynamoDBProperty]
-        public ApprovalStatus ApprovalStatus { get; set; }
-
-        [DynamoDBProperty]
         public string ApprovalStatusReason { get; set; }
 
         [DynamoDBProperty]
@@ -101,6 +98,9 @@ namespace ContractsApi.V1.Infrastructure
 
         [DynamoDBProperty]
         public string OptionToTaxLinkToGoogleDrive { get; set; }
+
+        [DynamoDBProperty(Converter = typeof(DynamoDbEnumConverter<ApprovalStatus>))]
+        public ApprovalStatus ApprovalStatus { get; set; }
 
         [DynamoDBProperty]
         public Frequency Rates { get; set; }


### PR DESCRIPTION
## Link to JIRA ticket

[Add a link to the JIRA ticket that the changes in this PR describe.](https://hackney.atlassian.net/browse/TS-1727)

## Describe this PR

### *What is the problem we're trying to solve*

approvalStatus enum was being stored in the contracts database as an integer and frequency as a string, we require both to be stored as strings.

### *What changes have we introduced*

using Amazon.DynamoDBv2.DataModel, I was able to add [DynamoDBProperty(Converter = typeof(DynamoDbEnumConverter<ApprovalStatus>))] to the ContractsDb class, afterwards generated required test to make sure the desired effect was accomplished.

Include any links to commits that introduce significant additions of code if they help explain the process of coming to the solution. e.g Addition of test database setup, addition of first test and production class, removal of buggy code, etc.

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

FE needs to be revised and we will also need to run a script through both DEV and STAGING databases to ensure all preexisting data complies with the new format. 
