### PR TITLE
TS-1885  - .NET8 upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/ContractsApi.Tests/ContractsApi.Tests.csproj
+++ b/ContractsApi.Tests/ContractsApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/ContractsApi.Tests/Dockerfile
+++ b/ContractsApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/ContractsApi.Tests/V1/Controllers/BaseControllerTests.cs
+++ b/ContractsApi.Tests/V1/Controllers/BaseControllerTests.cs
@@ -38,7 +38,7 @@ namespace ContractsApi.Tests.V1.Controllers
         public void GetCorrelationShouldReturnCorrelationIdWhenExists()
         {
             // Arrange
-            _stubHttpContext.Request.Headers.Add(HeaderConstants.CorrelationId, "123");
+            _stubHttpContext.Request.Headers.Append(HeaderConstants.CorrelationId, "123");
 
             // Act
             var result = _sut.GetCorrelationId();

--- a/ContractsApi/ContractsApi.csproj
+++ b/ContractsApi/ContractsApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/ContractsApi/Dockerfile
+++ b/ContractsApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/ContractsApi/V1/Controllers/ContractsApiController.cs
+++ b/ContractsApi/V1/Controllers/ContractsApiController.cs
@@ -66,7 +66,7 @@ namespace ContractsApi.V1.Controllers
             if (result.VersionNumber.HasValue)
                 eTag = result.VersionNumber.ToString();
 
-            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{eTag}\"").Tag);
+            HttpContext.Response.Headers.Append(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{eTag}\"").Tag);
 
             return Ok(result);
         }

--- a/ContractsApi/build.cmd
+++ b/ContractsApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/contracts-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/contracts-api.zip

--- a/ContractsApi/build.sh
+++ b/ContractsApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/contracts-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/contracts-api.zip

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -1,7 +1,7 @@
 service: contracts-api
 provider:
   name: aws
-  runtime: dotnet6
+  runtime: dotnet8
   memorySize: 2048
   tracing:
     lambda: true

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -15,7 +15,7 @@ plugins:
   - '@serverless/safeguards-plugin'
 
 package:
-  artifact: ./bin/release/net6.0/contracts-api.zip
+  artifact: ./bin/release/net8.0/contracts-api.zip
 
 functions:
   ContractsApi:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1885  

## Describe this PR

We need to upgrade our .NET projects to 8.0 before the current version/s become unsupported by AWS.
This PR includes such changes and a move from the .Add method to .Append to avoid exceptions when attempt 
ing to add a duplicate key (see also other .NET upgrades on other similarly structured APIs).