### PR TITLE
TS-1885: Severless upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ workflows:
             branches:
               only: master
       - deploy-to-development:
-         context:
+          context:
            - api-nuget-token-context
            - "Serverless Framework"
           requires:
@@ -315,12 +315,11 @@ workflows:
             branches:
               only: release
       - deploy-to-staging:
-         context:
+          context:
            - api-nuget-token-context
            - "Serverless Framework"
           requires:
             - terraform-apply-staging
-            - "Serverless Framework"
           filters:
             branches:
               only: release
@@ -361,12 +360,11 @@ workflows:
             branches:
               only: release
       - deploy-to-production:
-         context:
+          context:
            - api-nuget-token-context
            - "Serverless Framework"
           requires:
             - permit-production-release
-            - "Serverless Framework"
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-ecr: circleci/aws-ecr@9.3.7
+  aws-cli: circleci/aws-cli@5.1.1
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
@@ -118,7 +118,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless@^3
+          command: npm i -g serverless
       - run:
           name: Build lambda
           command: |
@@ -218,16 +218,22 @@ jobs:
           environment: "production"
   deploy-to-development:
     executor: docker-dotnet
+    context:
+      - "Serverless Framework"    
     steps:
       - deploy-lambda:
           stage: "development"
   deploy-to-staging:
     executor: docker-dotnet
+    context:
+      - "Serverless Framework"     
     steps:
       - deploy-lambda:
           stage: "staging"
   deploy-to-production:
     executor: docker-dotnet
+    context:
+      - "Serverless Framework"     
     steps:
       - deploy-lambda:
           stage: "production"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,8 +269,8 @@ workflows:
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
-            - "Serverless Framework"
             - terraform-apply-development         
+            - "Serverless Framework"
           filters:
             branches:
               only: master
@@ -316,8 +316,8 @@ workflows:
       - deploy-to-staging:
           context: api-nuget-token-context
           requires:
-            - "Serverless Framework"
             - terraform-apply-staging
+            - "Serverless Framework"
           filters:
             branches:
               only: release
@@ -360,8 +360,8 @@ workflows:
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
-            - "Serverless Framework"
             - permit-production-release
+            - "Serverless Framework"
           filters:
             branches:
               only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,10 +267,11 @@ workflows:
             branches:
               only: master
       - deploy-to-development:
-          context: api-nuget-token-context
+         context:
+           - api-nuget-token-context
+           - "Serverless Framework"
           requires:
             - terraform-apply-development         
-            - "Serverless Framework"
           filters:
             branches:
               only: master
@@ -314,7 +315,9 @@ workflows:
             branches:
               only: release
       - deploy-to-staging:
-          context: api-nuget-token-context
+         context:
+           - api-nuget-token-context
+           - "Serverless Framework"
           requires:
             - terraform-apply-staging
             - "Serverless Framework"
@@ -358,7 +361,9 @@ workflows:
             branches:
               only: release
       - deploy-to-production:
-          context: api-nuget-token-context
+         context:
+           - api-nuget-token-context
+           - "Serverless Framework"
           requires:
             - permit-production-release
             - "Serverless Framework"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,22 +218,16 @@ jobs:
           environment: "production"
   deploy-to-development:
     executor: docker-dotnet
-    context:
-      - "Serverless Framework"    
     steps:
       - deploy-lambda:
           stage: "development"
   deploy-to-staging:
     executor: docker-dotnet
-    context:
-      - "Serverless Framework"     
     steps:
       - deploy-lambda:
           stage: "staging"
   deploy-to-production:
     executor: docker-dotnet
-    context:
-      - "Serverless Framework"     
     steps:
       - deploy-lambda:
           stage: "production"
@@ -275,7 +269,8 @@ workflows:
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
-            - terraform-apply-development
+            - "Serverless Framework"
+            - terraform-apply-development         
           filters:
             branches:
               only: master
@@ -321,6 +316,7 @@ workflows:
       - deploy-to-staging:
           context: api-nuget-token-context
           requires:
+            - "Serverless Framework"
             - terraform-apply-staging
           filters:
             branches:
@@ -364,6 +360,7 @@ workflows:
       - deploy-to-production:
           context: api-nuget-token-context
           requires:
+            - "Serverless Framework"
             - permit-production-release
           filters:
             branches:


### PR DESCRIPTION
As part of our .NET upgrade work, we're also bumping Serverless to V4 as (apparently) V3 won't support .NET > 6.0 
Also upgraded the aws orbs.