### PR TITLE
chore: Align CODEOWNERS with agreed repo ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,4 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
+# This file specifies owners for pull request approval
+# See https://help.github.com/articles/about-code-owners/
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @Miles-Alford @LBHTKarki @martapederiva @sam-drumm @1JW1 @LBHJHeppinstall
+* @LBHackney-IT/targeted-services


### PR DESCRIPTION
This change adds or updates `CODEOWNERS` to match the simplified
teams structure agreed in April 2024.

### Why are we doing this?

We're doing this work to make any future restructure more straightforward, 
simplify management of our GitHub, and move to team-based permission model
to ease joiners/movers/leavers. 

This is step 3 in a 4-part consolidation:

1. Add agreed teams to the repositories they own
2. Bring team membership up-to-date
3. Update `CODEOWNERS` to use the simplified teams (**this PR**)
4. Remove old teams and individiduals from repositories

### Effect of this change

This change won't have a practical effect on day-to-day work in GitHub. 

In some cases more people will be able to approve a PR than previously, 
where smaller sub-teams are reconciled into the high-level teams. In general
this is an acceptable risk as those people _may_ be called upon to make changes,
however if the team feels the risk is too high we can create another team to
further restrict things as a subsequent piece of work.

### Testing this PR

1. Check the proposed change view, and confirm the `CODEOWNERS` file is marked 
as "valid".

### Merging this PR

This PR is one of many, as we apply the same change to all our repositories. 
Rather than expecting teams to merge these individually, we'll centrally check,
approve, and merge them as a batch, bypassing existing `CODEOWNERS` rules (because
many repositories have broken or out of date `CODEOWNERS` files). 

To keep this safe @spikeheap will pair up with another engineer.
