### PR TITLE
Ts 2045 add pre production workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,11 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
   terraform-init-and-plan-development:
     executor: docker-terraform
     steps:
@@ -216,6 +221,21 @@ jobs:
     steps:
       - terraform-apply:
           environment: "production"
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-compliance-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
   deploy-to-development:
     executor: docker-dotnet
     steps:
@@ -231,7 +251,11 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
-
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 workflows:
   check-and-deploy-development:
     jobs:
@@ -368,3 +392,76 @@ workflows:
           filters:
             branches:
               only: release
+  
+  deploy-terraform-pre-production:
+    jobs:
+      - permit-pre-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      # - terraform-apply-pre-production:
+      #     requires:
+      #       - permit-pre-production-terraform-deployment
+      #     filters:
+      #       branches:
+      #         only: ts-2045-add-pre-production-workflow
+
+  # deploy-code-pre-production:
+  #   jobs:
+  #     - permit-pre-production-code-workflow:
+  #         type: approval
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+  #     - build-and-test:
+  #         requires:
+  #           - permit-pre-production-code-workflow
+  #         context: 
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+  #     - assume-role-pre-production:
+  #         context: api-assume-role-housing-pre-production-context
+  #         requires:
+  #           - build-and-test
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+  #     - deploy-to-pre-production:
+  #         context:
+  #         - api-nuget-token-context
+  #         - "Serverless Framework"
+  #         requires:
+  #           - assume-role-pre-production        
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,45 +393,45 @@ workflows:
             branches:
               only: release
   
-  # deploy-terraform-pre-production:
-  #   jobs:
-  #     - permit-pre-production-terraform-workflow:
-  #         type: approval
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - assume-role-pre-production:
-  #         context: api-assume-role-housing-pre-production-context
-  #         requires:
-  #           - permit-pre-production-terraform-workflow
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - terraform-init-and-plan-pre-production:
-  #         requires:
-  #           - assume-role-pre-production
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - terraform-compliance-pre-production:
-  #         requires:
-  #           - terraform-init-and-plan-pre-production
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - permit-pre-production-terraform-deployment:
-  #         type: approval
-  #         requires:
-  #           - terraform-compliance-pre-production
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - terraform-apply-pre-production:
-  #         requires:
-  #           - permit-pre-production-terraform-deployment
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
+  deploy-terraform-pre-production:
+    jobs:
+      - permit-pre-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: release
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: release
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: release
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: release
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: release
 
   deploy-code-pre-production:
     jobs:
@@ -439,7 +439,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflow
+              only: release
       - build-and-test:
           requires:
             - permit-pre-production-code-workflow
@@ -448,14 +448,14 @@ workflows:
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflow
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflow
+              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -464,4 +464,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflow
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,12 +426,12 @@ workflows:
           filters:
             branches:
               only: ts-2045-add-pre-production-workflow
-      # - terraform-apply-pre-production:
-      #     requires:
-      #       - permit-pre-production-terraform-deployment
-      #     filters:
-      #       branches:
-      #         only: ts-2045-add-pre-production-workflow
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
 
   # deploy-code-pre-production:
   #   jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,75 +393,75 @@ workflows:
             branches:
               only: release
   
-  deploy-terraform-pre-production:
-    jobs:
-      - permit-pre-production-terraform-workflow:
-          type: approval
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-      - assume-role-pre-production:
-          context: api-assume-role-housing-pre-production-context
-          requires:
-            - permit-pre-production-terraform-workflow
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-      - terraform-init-and-plan-pre-production:
-          requires:
-            - assume-role-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-      - terraform-compliance-pre-production:
-          requires:
-            - terraform-init-and-plan-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-      - permit-pre-production-terraform-deployment:
-          type: approval
-          requires:
-            - terraform-compliance-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-      - terraform-apply-pre-production:
-          requires:
-            - permit-pre-production-terraform-deployment
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflow
-
-  # deploy-code-pre-production:
+  # deploy-terraform-pre-production:
   #   jobs:
-  #     - permit-pre-production-code-workflow:
+  #     - permit-pre-production-terraform-workflow:
   #         type: approval
-  #         filters:
-  #           branches:
-  #             only: ts-2045-add-pre-production-workflow
-  #     - build-and-test:
-  #         requires:
-  #           - permit-pre-production-code-workflow
-  #         context: 
-  #           - api-nuget-token-context
-  #           - SonarCloud
   #         filters:
   #           branches:
   #             only: ts-2045-add-pre-production-workflow
   #     - assume-role-pre-production:
   #         context: api-assume-role-housing-pre-production-context
   #         requires:
-  #           - build-and-test
+  #           - permit-pre-production-terraform-workflow
   #         filters:
   #           branches:
   #             only: ts-2045-add-pre-production-workflow
-  #     - deploy-to-pre-production:
-  #         context:
-  #         - api-nuget-token-context
-  #         - "Serverless Framework"
+  #     - terraform-init-and-plan-pre-production:
   #         requires:
-  #           - assume-role-pre-production        
+  #           - assume-role-pre-production
   #         filters:
   #           branches:
   #             only: ts-2045-add-pre-production-workflow
+  #     - terraform-compliance-pre-production:
+  #         requires:
+  #           - terraform-init-and-plan-pre-production
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+  #     - permit-pre-production-terraform-deployment:
+  #         type: approval
+  #         requires:
+  #           - terraform-compliance-pre-production
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+  #     - terraform-apply-pre-production:
+  #         requires:
+  #           - permit-pre-production-terraform-deployment
+  #         filters:
+  #           branches:
+  #             only: ts-2045-add-pre-production-workflow
+
+  deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - build-and-test:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow
+      - deploy-to-pre-production:
+          context:
+          - api-nuget-token-context
+          - "Serverless Framework"
+          requires:
+            - assume-role-pre-production        
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflow

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -50,97 +50,97 @@ functions:
           path: /swagger/{proxy+}
           method: GET
           private: false
-# resources:
+resources:
 
-#   Resources:
-    # lambdaExecutionRole:
-    #   Type: AWS::IAM::Role
-    #   Properties:
-    #     Path: /${self:service}/${self:provider.stage}/
-    #     RoleName: ${self:service}-lambdaExecutionRole
-    #     AssumeRolePolicyDocument:
-    #       Version: '2012-10-17'
-    #       Statement:
-    #         - Effect: Allow
-    #           Principal:
-    #             Service:
-    #               - lambda.amazonaws.com
-    #           Action: sts:AssumeRole
-    #     ManagedPolicyArns:
-    #       - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-    #       - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
-    #     Policies:
-    #       - PolicyName: postToSns
-    #         PolicyDocument:
-    #             Version: '2012-10-17'
-    #             Statement:
-    #               - Effect: Allow
-    #                 Action:
-    #                   - "sns:Publish"
-    #                 Resource:
-    #                   - ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
-    #       - PolicyName: manageLogs
-    #         PolicyDocument:
-    #           Version: '2012-10-17'
-    #           Statement:
-    #             - Effect: Allow
-    #               Action:
-    #                 - logs:CreateLogGroup
-    #                 - logs:CreateLogStream
-    #                 - logs:PutLogEvents
-    #               Resource:
-    #                 - 'Fn::Join':
-    #                     - ':'
-    #                     - - 'arn:aws:logs'
-    #                       - Ref: 'AWS::Region'
-    #                       - Ref: 'AWS::AccountId'
-    #                       - 'log-group:/aws/lambda/*:*:*'
-    #                 - Effect: "Allow"
-    #                   Action:
-    #                     - "s3:PutObject"
-    #                     - "s3:GetObject"
-    #                   Resource:
-    #                     Fn::Join:
-    #                       - ""
-    #                       - - "arn:aws:s3:::"
-    #                         - "Ref": "ServerlessDeploymentBucket"
-    #       - PolicyName: lambdaInvocation
-    #         PolicyDocument:
-    #           Version: '2012-10-17'
-    #           Statement:
-    #             - Effect: Allow
-    #               Action:
-    #                 - "lambda:InvokeFunction"
-    #               Resource: "*"
-    #       - PolicyName: dynamoDBAccess
-    #         PolicyDocument:
-    #             Version: '2012-10-17'
-    #             Statement:
-    #               - Effect: Allow
-    #                 Action:
-    #                   - "dynamodb:BatchGet*"
-    #                   - "dynamodb:BatchWrite"
-    #                   - "dynamodb:DeleteItem"
-    #                   - "dynamodb:DescribeStream"
-    #                   - "dynamodb:DescribeTable"
-    #                   - "dynamodb:Get*"
-    #                   - "dynamodb:PutItem"
-    #                   - "dynamodb:Query"
-    #                   - "dynamodb:Scan"
-    #                   - "dynamodb:UpdateItem"
-    #                 Resource:
-    #                   - 'Fn::Join':
-    #                       - ':'
-    #                       - - 'arn:aws:dynamodb'
-    #                         - Ref: 'AWS::Region'
-    #                         - Ref: 'AWS::AccountId'
-    #                         - 'table/Contracts'
-    #                   - 'Fn::Join':
-    #                       - ':'
-    #                       - - 'arn:aws:dynamodb'
-    #                         - Ref: 'AWS::Region'
-    #                         - Ref: 'AWS::AccountId'
-    #                         - 'table/Contracts/index/*'
+  Resources:
+    lambdaExecutionRole:
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /${self:service}/${self:provider.stage}/
+        RoleName: ${self:service}-lambdaExecutionRole
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - lambda.amazonaws.com
+              Action: sts:AssumeRole
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+        Policies:
+          - PolicyName: postToSns
+            PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "sns:Publish"
+                    Resource:
+                      - ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
+          - PolicyName: manageLogs
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource:
+                    - 'Fn::Join':
+                        - ':'
+                        - - 'arn:aws:logs'
+                          - Ref: 'AWS::Region'
+                          - Ref: 'AWS::AccountId'
+                          - 'log-group:/aws/lambda/*:*:*'
+                    - Effect: "Allow"
+                      Action:
+                        - "s3:PutObject"
+                        - "s3:GetObject"
+                      Resource:
+                        Fn::Join:
+                          - ''
+                          - - 'arn:aws:s3:::'
+                            - Ref: ServerlessDeploymentBucket
+          - PolicyName: lambdaInvocation
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - "lambda:InvokeFunction"
+                  Resource: "*"
+          - PolicyName: dynamoDBAccess
+            PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - "dynamodb:BatchGet*"
+                      - "dynamodb:BatchWrite"
+                      - "dynamodb:DeleteItem"
+                      - "dynamodb:DescribeStream"
+                      - "dynamodb:DescribeTable"
+                      - "dynamodb:Get*"
+                      - "dynamodb:PutItem"
+                      - "dynamodb:Query"
+                      - "dynamodb:Scan"
+                      - "dynamodb:UpdateItem"
+                    Resource:
+                      - 'Fn::Join':
+                          - ':'
+                          - - 'arn:aws:dynamodb'
+                            - Ref: 'AWS::Region'
+                            - Ref: 'AWS::AccountId'
+                            - 'table/Contracts'
+                      - 'Fn::Join':
+                          - ':'
+                          - - 'arn:aws:dynamodb'
+                            - Ref: 'AWS::Region'
+                            - Ref: 'AWS::AccountId'
+                            - 'table/Contracts/index/*'
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -145,6 +145,7 @@ custom:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer
@@ -165,3 +166,7 @@ custom:
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
+    pre-production:
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -50,106 +50,97 @@ functions:
           path: /swagger/{proxy+}
           method: GET
           private: false
-resources:
-  Conditions:
-    UseV3DeploymentBucketPolicy: 
-      Fn::Not:
-      - Fn::Equals:
-        - ${self:provider.stage}
-        - "pre-production"
-        
-  Resources:
-    lambdaExecutionRole:
-      Type: AWS::IAM::Role
-      Properties:
-        Path: /${self:service}/${self:provider.stage}/
-        RoleName: ${self:service}-lambdaExecutionRole
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - lambda.amazonaws.com
-              Action: sts:AssumeRole
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-          - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
-        Policies:
-          - PolicyName: postToSns
-            PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                  - Effect: Allow
-                    Action:
-                      - "sns:Publish"
-                    Resource:
-                      - ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
-          - PolicyName: manageLogs
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - logs:CreateLogGroup
-                    - logs:CreateLogStream
-                    - logs:PutLogEvents
-                  Resource:
-                    - 'Fn::Join':
-                        - ':'
-                        - - 'arn:aws:logs'
-                          - Ref: 'AWS::Region'
-                          - Ref: 'AWS::AccountId'
-                          - 'log-group:/aws/lambda/*:*:*'
-                - !If 
-                  - UseV3DeploymentBucketPolicy  
-                  - Effect: "Allow"
-                    Action:
-                      - "s3:PutObject"
-                      - "s3:GetObject"
-                    Resource:
-                      Fn::Join:
-                        - ""
-                        - - "arn:aws:s3:::"
-                          - !If [ UseV3DeploymentBucketPolicy, "Ref": "ServerlessDeploymentBucket", !Ref AWS::NoValue ]
-                  - !Ref AWS::NoValue
-          - PolicyName: lambdaInvocation
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                - Effect: Allow
-                  Action:
-                    - "lambda:InvokeFunction"
-                  Resource: "*"
-          - PolicyName: dynamoDBAccess
-            PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                  - Effect: Allow
-                    Action:
-                      - "dynamodb:BatchGet*"
-                      - "dynamodb:BatchWrite"
-                      - "dynamodb:DeleteItem"
-                      - "dynamodb:DescribeStream"
-                      - "dynamodb:DescribeTable"
-                      - "dynamodb:Get*"
-                      - "dynamodb:PutItem"
-                      - "dynamodb:Query"
-                      - "dynamodb:Scan"
-                      - "dynamodb:UpdateItem"
-                    Resource:
-                      - 'Fn::Join':
-                          - ':'
-                          - - 'arn:aws:dynamodb'
-                            - Ref: 'AWS::Region'
-                            - Ref: 'AWS::AccountId'
-                            - 'table/Contracts'
-                      - 'Fn::Join':
-                          - ':'
-                          - - 'arn:aws:dynamodb'
-                            - Ref: 'AWS::Region'
-                            - Ref: 'AWS::AccountId'
-                            - 'table/Contracts/index/*'
+# resources:
+
+#   Resources:
+    # lambdaExecutionRole:
+    #   Type: AWS::IAM::Role
+    #   Properties:
+    #     Path: /${self:service}/${self:provider.stage}/
+    #     RoleName: ${self:service}-lambdaExecutionRole
+    #     AssumeRolePolicyDocument:
+    #       Version: '2012-10-17'
+    #       Statement:
+    #         - Effect: Allow
+    #           Principal:
+    #             Service:
+    #               - lambda.amazonaws.com
+    #           Action: sts:AssumeRole
+    #     ManagedPolicyArns:
+    #       - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+    #       - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
+    #     Policies:
+    #       - PolicyName: postToSns
+    #         PolicyDocument:
+    #             Version: '2012-10-17'
+    #             Statement:
+    #               - Effect: Allow
+    #                 Action:
+    #                   - "sns:Publish"
+    #                 Resource:
+    #                   - ${ssm:/sns-topic/${self:provider.stage}/contracts/arn}
+    #       - PolicyName: manageLogs
+    #         PolicyDocument:
+    #           Version: '2012-10-17'
+    #           Statement:
+    #             - Effect: Allow
+    #               Action:
+    #                 - logs:CreateLogGroup
+    #                 - logs:CreateLogStream
+    #                 - logs:PutLogEvents
+    #               Resource:
+    #                 - 'Fn::Join':
+    #                     - ':'
+    #                     - - 'arn:aws:logs'
+    #                       - Ref: 'AWS::Region'
+    #                       - Ref: 'AWS::AccountId'
+    #                       - 'log-group:/aws/lambda/*:*:*'
+    #                 - Effect: "Allow"
+    #                   Action:
+    #                     - "s3:PutObject"
+    #                     - "s3:GetObject"
+    #                   Resource:
+    #                     Fn::Join:
+    #                       - ""
+    #                       - - "arn:aws:s3:::"
+    #                         - "Ref": "ServerlessDeploymentBucket"
+    #       - PolicyName: lambdaInvocation
+    #         PolicyDocument:
+    #           Version: '2012-10-17'
+    #           Statement:
+    #             - Effect: Allow
+    #               Action:
+    #                 - "lambda:InvokeFunction"
+    #               Resource: "*"
+    #       - PolicyName: dynamoDBAccess
+    #         PolicyDocument:
+    #             Version: '2012-10-17'
+    #             Statement:
+    #               - Effect: Allow
+    #                 Action:
+    #                   - "dynamodb:BatchGet*"
+    #                   - "dynamodb:BatchWrite"
+    #                   - "dynamodb:DeleteItem"
+    #                   - "dynamodb:DescribeStream"
+    #                   - "dynamodb:DescribeTable"
+    #                   - "dynamodb:Get*"
+    #                   - "dynamodb:PutItem"
+    #                   - "dynamodb:Query"
+    #                   - "dynamodb:Scan"
+    #                   - "dynamodb:UpdateItem"
+    #                 Resource:
+    #                   - 'Fn::Join':
+    #                       - ':'
+    #                       - - 'arn:aws:dynamodb'
+    #                         - Ref: 'AWS::Region'
+    #                         - Ref: 'AWS::AccountId'
+    #                         - 'table/Contracts'
+    #                   - 'Fn::Join':
+    #                       - ':'
+    #                       - - 'arn:aws:dynamodb'
+    #                         - Ref: 'AWS::Region'
+    #                         - Ref: 'AWS::AccountId'
+    #                         - 'table/Contracts/index/*'
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -51,6 +51,13 @@ functions:
           method: GET
           private: false
 resources:
+  Conditions:
+    UseV3DeploymentBucketPolicy: 
+      Fn::Not:
+      - Fn::Equals:
+        - ${self:provider.stage}
+        - "pre-production"
+        
   Resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
@@ -94,15 +101,18 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                # - Effect: "Allow"
-                #   Action:
-                #     - "s3:PutObject"
-                #     - "s3:GetObject"
-                #   Resource:
-                #     Fn::Join:
-                #       - ""
-                #       - - "arn:aws:s3:::"
-                #         - "Ref": "ServerlessDeploymentBucket"
+                - !If 
+                  - UseV3DeploymentBucketPolicy  
+                  - Effect: "Allow"
+                    Action:
+                      - "s3:PutObject"
+                      - "s3:GetObject"
+                    Resource:
+                      Fn::Join:
+                        - ""
+                        - - "arn:aws:s3:::"
+                          - "Ref": "ServerlessDeploymentBucket"
+                  - !Ref AWS::NoValue
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -95,15 +95,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                    - Effect: "Allow"
-                      Action:
-                        - "s3:PutObject"
-                        - "s3:GetObject"
-                      Resource:
-                        Fn::Join:
-                          - ''
-                          - - 'arn:aws:s3:::'
-                            - Ref: ServerlessDeploymentBucket
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -58,8 +58,6 @@ resources:
         - ${self:provider.stage}
         - "pre-production"
         
-    ServerlessDeploymentBucketRefExists: !Not [ !IsSet ServerlessDeploymentBucket ]
-
   Resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
@@ -113,7 +111,7 @@ resources:
                       Fn::Join:
                         - ""
                         - - "arn:aws:s3:::"
-                          - !If [ ServerlessDeploymentBucketRefExists, !Ref ServerlessDeploymentBucket, !Ref AWS::NoValue ]
+                          - !If [ UseV3DeploymentBucketPolicy, "Ref": "ServerlessDeploymentBucket", !Ref AWS::NoValue ]
                   - !Ref AWS::NoValue
           - PolicyName: lambdaInvocation
             PolicyDocument:

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -58,6 +58,8 @@ resources:
         - ${self:provider.stage}
         - "pre-production"
         
+    ServerlessDeploymentBucketRefExists: !Not [ !IsSet ServerlessDeploymentBucket ]
+
   Resources:
     lambdaExecutionRole:
       Type: AWS::IAM::Role
@@ -111,7 +113,7 @@ resources:
                       Fn::Join:
                         - ""
                         - - "arn:aws:s3:::"
-                          - "Ref": "ServerlessDeploymentBucket"
+                          - !If [ ServerlessDeploymentBucketRefExists, !Ref ServerlessDeploymentBucket, !Ref AWS::NoValue ]
                   - !Ref AWS::NoValue
           - PolicyName: lambdaInvocation
             PolicyDocument:

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -94,15 +94,15 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
+                # - Effect: "Allow"
+                #   Action:
+                #     - "s3:PutObject"
+                #     - "s3:GetObject"
+                #   Resource:
+                #     Fn::Join:
+                #       - ""
+                #       - - "arn:aws:s3:::"
+                #         - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'

--- a/terraform/pre-production/dynamodb.tf
+++ b/terraform/pre-production/dynamodb.tf
@@ -1,0 +1,40 @@
+resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
+  name           = "Contracts"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "targetId"
+    type = "S"
+  }
+
+  attribute {
+    name = "targetContractNumber"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name            = "ContractsByTargetId"
+    hash_key        = "targetId"
+    range_key       = "targetContractNumber"
+    write_capacity  = 10
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
+  tags = merge(
+    local.default_tags,
+    { BackupPolicy = "Dev", Backup = false }
+  )
+
+  point_in_time_recovery {
+    enabled = false
+  }
+}

--- a/terraform/pre-production/dynamodb.tf
+++ b/terraform/pre-production/dynamodb.tf
@@ -31,7 +31,7 @@ resource "aws_dynamodb_table" "contractsapi_dynamodb_table" {
 
   tags = merge(
     local.default_tags,
-    { BackupPolicy = "Dev", Backup = false }
+    { BackupPolicy = "Dev", Backup = false, Confidentiality = "Internal" }
   )
 
   point_in_time_recovery {

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -33,3 +33,16 @@ terraform {
     dynamodb_table = "housing-pre-production-terraform-state-lock"
   }
 }
+
+resource "aws_sns_topic" "contracts" {
+  name                        = "contracts.fifo"
+  fifo_topic                  = true
+  content_based_deduplication = true
+  kms_master_key_id           = "alias/aws/sns"
+}
+
+resource "aws_ssm_parameter" "contracts_sns_arn" {
+  name  = "/sns-topic/pre-production/contracts/arn"
+  type  = "String"
+  value = aws_sns_topic.contracts.arn
+}

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  default_tags = {
+    Name              = "contracts-api-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/contracts-api/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -14,13 +14,16 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+#using prod for environment as agreed with CE
 locals {
   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
   default_tags = {
     Name              = "contracts-api-${var.environment_name}"
-    Environment       = var.environment_name
+    Environment       = "prod"
     terraform-managed = true
     project_name      = var.project_name
+    Application       = "MTFH Housing Pre-Production"
+    TeamEmail         = "developementteam@hackney.gov.uk"
   }
 }
 

--- a/terraform/pre-production/terraform-compliance/dynamodb.feature
+++ b/terraform/pre-production/terraform-compliance/dynamodb.feature
@@ -8,7 +8,7 @@ Feature: DynamoDB is used as our NoSQL database service
     Then it must contain tags
     And it must contain BackupPolicy
 
-  Scenario: Ensure point in time recovery enabled
+  Scenario: Ensure point in time recovery disabled
     Given I have aws_dynamodb_table defined
     Then it must contain point_in_time_recovery
-    And its enabled property must be true
+    And its enabled property must be false

--- a/terraform/pre-production/terraform-compliance/dynamodb.feature
+++ b/terraform/pre-production/terraform-compliance/dynamodb.feature
@@ -1,0 +1,14 @@
+Feature: DynamoDB is used as our NoSQL database service
+  In order to improve security
+  As engineers
+  We'll ensure our DynamoDB tables are configured correctly
+
+  Scenario: Ensure BackupPolicy tag is present
+    Given I have aws_dynamodb_table defined
+    Then it must contain tags
+    And it must contain BackupPolicy
+
+  Scenario: Ensure point in time recovery enabled
+    Given I have aws_dynamodb_table defined
+    Then it must contain point_in_time_recovery
+    And its enabled property must be true

--- a/terraform/pre-production/terraform-compliance/sns.feature
+++ b/terraform/pre-production/terraform-compliance/sns.feature
@@ -1,0 +1,8 @@
+Feature: SNS is used as our notification service
+    In order to improve security
+    As engineers
+    We'll use ensure our SNS topics are configured correctly
+
+    Scenario: Ensure encryption is enabled
+        Given I have aws_sns_topic defined
+        Then it must contain kms_master_key_id

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-production"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
[TS-2045](https://hackney.atlassian.net/browse/TS-2045)

Add resources and deployment workflow for housing-pre-production account.

Removes the policy from `lambdaExecutionRole` that's causing issues with new accounts and Serverless V4. Also it does look like unnecessary anyway, but we need to test that by deploying it to dev firt.

