### PR TITLE
TS-2145 deploy pre-production Lambda to VPC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,141 +257,141 @@ jobs:
       - deploy-lambda:
           stage: "pre-production"
 workflows:
-  # check-and-deploy-development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #     - build-and-test:
-  #         context: 
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-development:
-  #         context:
-  #          - api-nuget-token-context
-  #          - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-development         
-  #         filters:
-  #           branches:
-  #             only: master
-  # check-and-deploy-staging-and-production:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - build-and-test:
-  #         context: 
-  #           - api-nuget-token-context
-  #           - SonarCloud          
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #           - build-and-test
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-staging:
-  #         context:
-  #          - api-nuget-token-context
-  #          - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #           - deploy-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-compliance-production
-  #     - terraform-apply-production:
-  #         requires:
-  #           - permit-production-terraform-release
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-apply-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-production:
-  #         context:
-  #          - api-nuget-token-context
-  #          - "Serverless Framework"
-  #         requires:
-  #           - permit-production-release
-  #         filters:
-  #           branches:
-  #             only: release
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context: 
+            - api-nuget-token-context
+            - SonarCloud
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: master
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+          filters:
+            branches:
+              only: master
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+          filters:
+            branches:
+              only: master
+      - deploy-to-development:
+          context:
+           - api-nuget-token-context
+           - "Serverless Framework"
+          requires:
+            - terraform-apply-development         
+          filters:
+            branches:
+              only: master
+  check-and-deploy-staging-and-production:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
+      - build-and-test:
+          context: 
+            - api-nuget-token-context
+            - SonarCloud          
+          filters:
+            branches:
+              only: release
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+            - build-and-test
+          filters:
+            branches:
+              only: release
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: release
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-staging:
+          context:
+           - api-nuget-token-context
+           - "Serverless Framework"
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: release
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: release
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - terraform-compliance-production
+      - terraform-apply-production:
+          requires:
+            - permit-production-terraform-release
+          filters:
+            branches:
+              only: release
+      - permit-production-release:
+          type: approval
+          requires:
+            - terraform-apply-production
+          filters:
+            branches:
+              only: release
+      - deploy-to-production:
+          context:
+           - api-nuget-token-context
+           - "Serverless Framework"
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: release
   
   deploy-terraform-pre-production:
     jobs:
@@ -399,7 +399,7 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2145-move-lambda-to-new-security-group
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
@@ -420,14 +420,10 @@ workflows:
 
   deploy-code-pre-production:
     jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
+      - build-and-test:
           filters:
             branches:
-              only: ts-2145-move-lambda-to-new-security-group
-      - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
+              only: release
           context: 
             - api-nuget-token-context
             - SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,141 +257,141 @@ jobs:
       - deploy-lambda:
           stage: "pre-production"
 workflows:
-  check-and-deploy-development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-      - build-and-test:
-          context: 
-            - api-nuget-token-context
-            - SonarCloud
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: master
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: master
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-          filters:
-            branches:
-              only: master
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-          filters:
-            branches:
-              only: master
-      - deploy-to-development:
-          context:
-           - api-nuget-token-context
-           - "Serverless Framework"
-          requires:
-            - terraform-apply-development         
-          filters:
-            branches:
-              only: master
-  check-and-deploy-staging-and-production:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: release
-      - build-and-test:
-          context: 
-            - api-nuget-token-context
-            - SonarCloud          
-          filters:
-            branches:
-              only: release
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: release
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: release
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-staging:
-          context:
-           - api-nuget-token-context
-           - "Serverless Framework"
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: release
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: release
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: release
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - terraform-compliance-production
-      - terraform-apply-production:
-          requires:
-            - permit-production-terraform-release
-          filters:
-            branches:
-              only: release
-      - permit-production-release:
-          type: approval
-          requires:
-            - terraform-apply-production
-          filters:
-            branches:
-              only: release
-      - deploy-to-production:
-          context:
-           - api-nuget-token-context
-           - "Serverless Framework"
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: release
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #     - build-and-test:
+  #         context: 
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-development:
+  #         context:
+  #          - api-nuget-token-context
+  #          - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-development         
+  #         filters:
+  #           branches:
+  #             only: master
+  # check-and-deploy-staging-and-production:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - build-and-test:
+  #         context: 
+  #           - api-nuget-token-context
+  #           - SonarCloud          
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #           - build-and-test
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-staging:
+  #         context:
+  #          - api-nuget-token-context
+  #          - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #           - deploy-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-compliance-production
+  #     - terraform-apply-production:
+  #         requires:
+  #           - permit-production-terraform-release
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-apply-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-production:
+  #         context:
+  #          - api-nuget-token-context
+  #          - "Serverless Framework"
+  #         requires:
+  #           - permit-production-release
+  #         filters:
+  #           branches:
+  #             only: release
   
   deploy-terraform-pre-production:
     jobs:
@@ -399,39 +399,24 @@ workflows:
           type: approval
           filters:
             branches:
-              only: release
+              only: ts-2145-move-lambda-to-new-security-group
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
-          filters:
-            branches:
-              only: release
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
-          filters:
-            branches:
-              only: release
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
-          filters:
-            branches:
-              only: release
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
-          filters:
-            branches:
-              only: release
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
-          filters:
-            branches:
-              only: release
 
   deploy-code-pre-production:
     jobs:
@@ -439,29 +424,20 @@ workflows:
           type: approval
           filters:
             branches:
-              only: release
+              only: ts-2145-move-lambda-to-new-security-group
       - build-and-test:
           requires:
             - permit-pre-production-code-workflow
           context: 
             - api-nuget-token-context
             - SonarCloud
-          filters:
-            branches:
-              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
           - "Serverless Framework"
           requires:
             - assume-role-pre-production        
-          filters:
-            branches:
-              only: release

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -159,6 +159,8 @@ custom:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34
     pre-production:
+      securityGroupIds:
+        - sg-0d6267930f0c809b6
       subnetIds:
         - subnet-08aa35159a8706faa
         - subnet-0b848c5b14f841dfb

--- a/terraform/pre-production/aws_security_group.tf
+++ b/terraform/pre-production/aws_security_group.tf
@@ -1,0 +1,22 @@
+data "aws_vpc" "pre_production_vpc" {
+  tags = {
+    Name = "housing-pre-prod-pre-prod"
+  }
+}
+
+resource "aws_security_group" "lambda" {
+  name                   = "contracts-api-lambda-sg"
+  description            = "Security group used by the contracts API lambda function"
+  vpc_id                 = data.aws_vpc.pre_production_vpc.id
+  revoke_rules_on_delete = true
+}
+
+resource "aws_security_group_rule" "egress_https" {
+  security_group_id = aws_security_group.lambda.id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow egress on port 443"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+}


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2145](https://hackney.atlassian.net/browse/TS-2145)

## Describe this PR

### *What is the problem we're trying to solve*

All Lambda functions should be deployed to a VPC and use their own dedicated security group as per CE team's recommendations and other best practises.

### *What changes have we introduced*

1. Add new security group
2. Deploy Lambda to VPC
3. Tidy up branch filters on pre-production workflows

Please note this change only applies to pre-production environment.

[TS-2145]: https://hackney.atlassian.net/browse/TS-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ