### PR TITLE
TS-2029: Disable block suspension/unsuspension

### DIFF
--- a/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/ContractsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -220,7 +220,6 @@ namespace ContractsApi.Tests.V1.Gateways
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
             request.HandbackDate = today;
-            request.SuspensionDate = null;
 
             Func<Task<UpdateEntityResult<ContractDb>>> func = async () =>
                 await _classUnderTest.PatchContract(contractId, request, It.IsAny<string>(), It.IsAny<int>()).ConfigureAwait(false);
@@ -264,7 +263,7 @@ namespace ContractsApi.Tests.V1.Gateways
 
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
-            var suppliedVersion = 1;
+            var suppliedVersion = 0;
             request.HandbackDate = tomorrow;
             request.SuspensionDate = tomorrow;
             request.ContractManagement.AssetHierarchy = AssetHierarchy.Block;
@@ -275,7 +274,7 @@ namespace ContractsApi.Tests.V1.Gateways
             await func.Should().ThrowAsync<SuspendingBlockException>().WithMessage($"It is not possible to add a suspension to blocks");
             _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.SaveAsync to update id {contractId}",
                 Times.Never());
-        }        
+        }
 
         [Fact]
         public async Task PatchContractSuccessfullyUpdatesAContract()
@@ -289,6 +288,7 @@ namespace ContractsApi.Tests.V1.Gateways
             var contractId = currentContract.Id;
             var request = _fixture.Create<EditContractRequest>();
             request.HandbackDate = tomorrow;
+            request.SuspensionDate = null;
             var requestBody = "{ \"StartDate\":\"key7d2d6e42-0cbf-411a-b66c-bc35da8b6061\":{ },\"EndDate\":\"89017f11-95f7-434d-96f8-178e33685fb4\"}}";
             var suppliedVersion = 0;
 

--- a/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
+++ b/ContractsApi/V1/Boundary/Requests/CreateContractRequestObject.cs
@@ -38,5 +38,6 @@ namespace ContractsApi.V1.Boundary.Requests
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }
         public string ReasonForSuspensionDate { get; set; }
+        public ContractManagement ContractManagementInfo { get; set; }
     }
 }

--- a/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
+++ b/ContractsApi/V1/Boundary/Requests/EditContractRequest.cs
@@ -35,6 +35,7 @@ namespace ContractsApi.V1.Boundary.Requests
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }
         public string ReasonForSuspensionDate { get; set; }
+        public ContractManagement ContractManagement { get; set; }
     }
 
     public class CustomEditContractValidation : AbstractValidator<EditContractRequest>

--- a/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
+++ b/ContractsApi/V1/Boundary/Response/ContractResponseObject.cs
@@ -41,5 +41,6 @@ namespace ContractsApi.V1.Boundary.Response
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }
         public string ReasonForSuspensionDate { get; set; }
+        public ContractManagement ContractManagementInfo { get; set; }
     }
 }

--- a/ContractsApi/V1/Domain/Contract.cs
+++ b/ContractsApi/V1/Domain/Contract.cs
@@ -40,5 +40,6 @@ namespace ContractsApi.V1.Domain
         public TenureType DefaultTenureType { get; set; }
         public DateTime? SuspensionDate { get; set; }
         public string ReasonForSuspensionDate { get; set; }
+        public ContractManagement ContractManagementInfo { get; set; }
     }
 }

--- a/ContractsApi/V1/Domain/ContractManagement.cs
+++ b/ContractsApi/V1/Domain/ContractManagement.cs
@@ -5,6 +5,6 @@ namespace ContractsApi.V1.Domain
     public class ContractManagement
     {
         public AssetHierarchy AssetHierarchy { get; set; }
-        public Guid? ParentAssetId { get; set; }
+        public Guid? ParentContractId { get; set; }
     }
 }

--- a/ContractsApi/V1/Domain/ContractManagement.cs
+++ b/ContractsApi/V1/Domain/ContractManagement.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ContractsApi.V1.Domain
+{
+    public class ContractManagement
+    {
+        public AssetHierarchy AssetHierarchy { get; set; }
+        public Guid ParentAssetId { get; set; }
+    }
+}

--- a/ContractsApi/V1/Domain/ContractManagement.cs
+++ b/ContractsApi/V1/Domain/ContractManagement.cs
@@ -5,6 +5,6 @@ namespace ContractsApi.V1.Domain
     public class ContractManagement
     {
         public AssetHierarchy AssetHierarchy { get; set; }
-        public Guid ParentAssetId { get; set; }
+        public Guid? ParentAssetId { get; set; }
     }
 }

--- a/ContractsApi/V1/Domain/Enums.cs
+++ b/ContractsApi/V1/Domain/Enums.cs
@@ -19,4 +19,13 @@ namespace ContractsApi.V1.Domain
         Approved,
         PendingReapproval
     }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AssetHierarchy
+    {
+        StandaloneUnit,
+        Block,
+        ChildUnit
+    }
+
 }

--- a/ContractsApi/V1/Factories/CreateRequestFactory.cs
+++ b/ContractsApi/V1/Factories/CreateRequestFactory.cs
@@ -42,7 +42,8 @@ namespace ContractsApi.V1.Factories
                 Rates = request.Rates,
                 DefaultTenureType = request.DefaultTenureType,
                 SuspensionDate = request.SuspensionDate,
-                ReasonForSuspensionDate = request.ReasonForSuspensionDate
+                ReasonForSuspensionDate = request.ReasonForSuspensionDate,
+                ContractManagementInfo = request.ContractManagementInfo
             };
         }
     }

--- a/ContractsApi/V1/Factories/EntityFactory.cs
+++ b/ContractsApi/V1/Factories/EntityFactory.cs
@@ -44,7 +44,8 @@ namespace ContractsApi.V1.Factories
                 Rates = contractDb.Rates,
                 DefaultTenureType = contractDb.DefaultTenureType,
                 SuspensionDate = contractDb.SuspensionDate,
-                ReasonForSuspensionDate = contractDb.ReasonForSuspensionDate
+                ReasonForSuspensionDate = contractDb.ReasonForSuspensionDate,
+                ContractManagementInfo = contractDb.ContractManagementInfo
             };
         }
 
@@ -84,7 +85,8 @@ namespace ContractsApi.V1.Factories
                 Rates = contract.Rates,
                 DefaultTenureType = contract.DefaultTenureType,
                 SuspensionDate = contract.SuspensionDate,
-                ReasonForSuspensionDate = contract.ReasonForSuspensionDate
+                ReasonForSuspensionDate = contract.ReasonForSuspensionDate,
+                ContractManagementInfo = contract.ContractManagementInfo
             };
         }
     }

--- a/ContractsApi/V1/Factories/ResponseFactory.cs
+++ b/ContractsApi/V1/Factories/ResponseFactory.cs
@@ -44,7 +44,8 @@ namespace ContractsApi.V1.Factories
                 Rates = contract.Rates,
                 DefaultTenureType = contract.DefaultTenureType,
                 SuspensionDate = contract.SuspensionDate,
-                ReasonForSuspensionDate = contract.ReasonForSuspensionDate
+                ReasonForSuspensionDate = contract.ReasonForSuspensionDate,
+                ContractManagementInfo = contract.ContractManagementInfo
             };
         }
 

--- a/ContractsApi/V1/Gateways/DynamoDbGateway.cs
+++ b/ContractsApi/V1/Gateways/DynamoDbGateway.cs
@@ -153,6 +153,10 @@ namespace ContractsApi.V1.Gateways
                 if (existingContract.StartDate > contractRequestBody.HandbackDate || existingContract.StartDate is null)
                     throw new StartAndHandbackDatesConflictException(existingContract.StartDate, contractRequestBody.HandbackDate);
             }
+            if ((contractRequestBody.ContractManagement.AssetHierarchy == AssetHierarchy.Block) && (contractRequestBody.SuspensionDate is not null))
+            {
+                throw new SuspendingBlockException();
+            }
             var response = _updater.UpdateEntity(existingContract, requestBody, contractRequestBody);
 
             if (response.NewValues.Any())

--- a/ContractsApi/V1/Infrastructure/ContractsDb.cs
+++ b/ContractsApi/V1/Infrastructure/ContractsDb.cs
@@ -110,5 +110,8 @@ namespace ContractsApi.V1.Infrastructure
 
         [DynamoDBProperty]
         public string ReasonForSuspensionDate { get; set; }
+
+        [DynamoDBProperty]
+        public ContractManagement ContractManagementInfo { get; set; }
     }
 }

--- a/ContractsApi/V1/Infrastructure/Exceptions/SuspendingBlockException.cs
+++ b/ContractsApi/V1/Infrastructure/Exceptions/SuspendingBlockException.cs
@@ -5,7 +5,7 @@ namespace ContractsApi.V1.Infrastructure.Exceptions
     public class SuspendingBlockException : Exception
     {
         public SuspendingBlockException()
-            : base(string.Format("It is not possible to add a suspesion to blocks"))
+            : base(string.Format("It is not possible to add a suspension to blocks"))
         {
         }
     }

--- a/ContractsApi/V1/Infrastructure/Exceptions/SuspendingBlockException.cs
+++ b/ContractsApi/V1/Infrastructure/Exceptions/SuspendingBlockException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ContractsApi.V1.Infrastructure.Exceptions
+{
+    public class SuspendingBlockException : Exception
+    {
+        public SuspendingBlockException()
+            : base(string.Format("It is not possible to add a suspesion to blocks"))
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-2029 

## Describe this PR

### *What is the problem we're trying to solve*

Users need to be able to suspend/unsuspend child units but blocks cannot be suspended.
To make this possible we are finally introducing the concept of PH to contracts, by adding the subentity `ContractManagement`
It contains the hierarchical position of the asset to which the contract is tied and a guid to be populated with a potential `ParentContractId`.

