### PR TITLE
Bump JWT core to 1.87.0 for Cognito support & Fix Sonar Scanner's `Missing blob` error.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - sonarcloud/scan
       - run:

--- a/ContractsApi.Tests/ContractsApi.Tests.csproj
+++ b/ContractsApi.Tests/ContractsApi.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="DeepCloner" Version="0.10.4" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.73.0-feat-patch-api-g0004" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.74.0-feat-generic-sns0002" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/ContractsApi/ContractsApi.csproj
+++ b/ContractsApi/ContractsApi.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.73.0-feat-patch-api-g0004" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.74.0-feat-generic-sns0002" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.72 -> 1.84 -> 1.87)_.
 - Fix Sonar Scanner's "Missing Blob" error caused by a **recent change** of CircleCI's inbuilt checkout step's **default settings** from pulling full git history to pulling only the latest commit's code snapshot.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.
 - Fix the pipeline to unblock deployment.

# Notes:
 - The version `1.84.0` in between is an unintentional release triggered by a renamed variable in `nuget.config`. So `1.84.0` is identical to the `1.72.0`.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.

# Fixed pipeline error snippet:
```
ERROR: Error during SonarScanner Engine execution
java.lang.IllegalStateException: java.util.concurrent.ExecutionException: java.lang.IllegalStateException:
org.eclipse.jgit.errors.MissingObjectException: Missing blob 2f079fa36777adb2885771f2260d160aae7e7510
        at org.sonar.scm.git.blame.FileBlamer.waitForTasks(FileBlamer.java:239)
        at org.sonar.scm.git.blame.FileBlamer.blameWithFileDiffs(FileBlamer.java:214)
        at org.sonar.scm.git.blame.FileBlamer.blameParent(FileBlamer.java:134)
        at org.sonar.scm.git.blame.BlameGenerator.process(BlameGenerator.java:149)
```