### PR TITLE
Switch to Cognito authorizer on `development` and `staging`.

### DIFF
--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -135,7 +135,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:

--- a/ContractsApi/serverless.yml
+++ b/ContractsApi/serverless.yml
@@ -134,7 +134,7 @@ resources:
                             - 'table/Contracts/index/*'
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew


### PR DESCRIPTION
# What:
 - Switch to the Cognito authorizer on `development` environment.
 - Switch to the Cognito authorizer on `staging` environment.

# Why:
 - Part of cognito authentication flow rolled out to staging. This API not being actively used is a perfect target for testing.
